### PR TITLE
Pick percentile items consistently in histograms

### DIFF
--- a/src/exometer_histogram.erl
+++ b/src/exometer_histogram.erl
@@ -246,18 +246,13 @@ revsort(L) ->
     lists:sort(fun erlang:'>'/2, L).
 
 p(50, N) -> perc(0.5, N);
-p(75, N) -> perc(0.25, N);
-p(90, N) -> perc(0.1, N);
-p(95, N) -> perc(0.05, N);
-p(99, N) -> perc(0.01, N);
-p(999,N) -> perc(0.001, N).
+p(75, N) -> perc(0.75, N);
+p(90, N) -> perc(0.9, N);
+p(95, N) -> perc(0.95, N);
+p(99, N) -> perc(0.99, N);
+p(999,N) -> perc(0.999, N).
 
-perc(P, Len) when P > 1.0 ->
-    round((P / 10) * Len) + 1;
-perc(P, Len) ->
-    round(P * Len) + 1.
-
-
+perc(P, N) -> N - exometer_util:perc(P, N) + 1.
 
 add_extra(Length, L, []) ->
     {Length, L};

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -22,6 +22,7 @@
     get_statistics/3,
     get_statistics2/4,
     pick_items/2,
+    perc/2,
     histogram/1,
     histogram/2,
     drop_duplicates/1,
@@ -247,7 +248,7 @@ get_statistics2(L, Sorted, Total, Mean) ->
     Items = [{min,1}, {50, P50}, {median, P50}, {75, perc(0.75,L)},
              {90, perc(0.9,L)}, {95, perc(0.95,L)}, {99, perc(0.99,L)},
              {999, perc(0.999,L)}, {max,L}],
-    [{n,L}, {mean, Mean}, {total, Total} | pick_items(Sorted, 1, Items)].
+    [{n,L}, {mean, Mean}, {total, Total} | pick_items(Sorted, Items)].
 
 -spec pick_items([number()], [{atom() | integer(), integer()}]) ->
 			[{atom(), number()}].

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -27,6 +27,7 @@
     test_update_or_create2/1,
     test_default_override/1,
     test_std_histogram/1,
+    test_slot_histogram/1,
     test_std_duration/1,
     test_folsom_histogram/1,
     test_aggregate/1,
@@ -78,6 +79,7 @@ groups() ->
      {test_histogram, [shuffle],
       [
        test_std_histogram,
+       test_slot_histogram,
        test_std_duration,
        test_folsom_histogram,
        test_aggregate,
@@ -237,6 +239,17 @@ test_std_histogram(_Config) ->
     [ok = update_(C,V) || V <- vals()],
     {_, {ok,DPs}} = timer:tc(exometer, get_value, [C]),
     [{n,134},{mean,2126866},{min,1},{max,9},{median,2},
+     {50,2},{75,3},{90,4},{95,5},{99,8},{999,9}] = scale_mean(DPs),
+    ok.
+
+test_slot_histogram(_Config) ->
+    C = [?MODULE, hist, ?LINE],
+    ok = exometer:new(C, histogram, [{histogram_module, exometer_slot_slide},
+				     {keep_high, 100},
+                                     {truncate, false}]),
+    [ok = update_(C,V) || V <- vals()],
+    {_, {ok,DPs}} = timer:tc(exometer, get_value, [C]),
+    [{n,_},{mean,2126866},{min,1},{max,9},{median,2},
      {50,2},{75,3},{90,4},{95,5},{99,8},{999,9}] = scale_mean(DPs),
     ok.
 


### PR DESCRIPTION
The slot_slide version of histograms picks percentile items from the skew
heap (if configured). In this case, it picks from a reversed list, since
the heap keeps only the largest values. A slight difference in percent
calculations could cause an off-by-one error when comparing the items
picked by the exometer_slide and the exometer_slot_slide histograms.