### PR TITLE
Switched the order of arguments in exometer_report call

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -1541,7 +1541,7 @@ reporter_init(Reporter, Opts) ->
 reporter_loop(Module, St) ->
     NSt = receive
               {exometer_report, Metric, DataPoint, Extra, Value } ->
-                  case Module:exometer_report(Metric, DataPoint, Extra, Value, St) of
+                  case Module:exometer_report(Metric, DataPoint, Value, Extra, St) of
                       {ok, St1} -> {ok, St1};
                       _ -> {ok, St}
                   end;


### PR DESCRIPTION
The way of calling the callback function is incosistent with its definition. The definition:

`-callback exometer_report(metric(), datapoint(), value(), extra(), mod_state()) -> callback_result().` 

so with previous implementation the `value()` was passed under the `extra()` argument and vice-versa.

This change modifies the API, so you might want to modify the callback definition insted.