### PR TITLE
Switched the order of arguments in the callback definition

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -216,7 +216,7 @@
 -callback exometer_init(options()) -> callback_result().
 
 -callback exometer_report(metric(), datapoint(),
-                          value(), extra(), mod_state()) ->
+                          extra(), value(), mod_state()) ->
     callback_result().
 
 -callback exometer_subscribe(metric(), datapoint(),


### PR DESCRIPTION
As previously discussed, there is an incosistency between the callback definition and its usage. This pull request fixes the callback definition.