### PR TITLE
Avoid crashing when calling resubscribe() with a non-integer interval

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -1092,12 +1092,14 @@ resubscribe(#subscriber{key = #key{reporter = RName,
 				   datapoint = DataPoint,
 				   extra = Extra} = Key,
 			t_ref = OldTRef,
-			interval = Interval}) ->
+			interval = Interval}) when is_integer(Interval) ->
     try_send(RName, {exometer_subscribe, Metric, DataPoint, Interval, Extra}),
     cancel_timer(OldTRef),
     TRef = erlang:send_after(Interval, self(),
 			     subscr_timer_msg(Key, Interval)),
-    ets:update_element(?EXOMETER_SUBS, Key, [{#subscriber.t_ref, TRef}]).
+    ets:update_element(?EXOMETER_SUBS, Key, [{#subscriber.t_ref, TRef}]);
+
+resubscribe(_) -> undefined.
 
 handle_report(#key{reporter = Reporter} = Key, Interval, TS, #st{} = St) ->
     _ = case ets:member(?EXOMETER_SUBS, Key) andalso


### PR DESCRIPTION
Hi.

We've been using exometer since before version 1.1 and recently decided to update to the master branch. The upgrade process went smoothly except for one failure.

In our project, we statically configure a set of named intervals for the `statsd` reporter like so:

```erl
{reporters, [
  {exometer_report_statsd, [
    {intervals, [
      {foo_interval, 1000, 0}, 
      {bar_interval, 1000, 100}
    ]}
  ]}
]}
```

Those intervals are then used instead of numbers when statically configuring subscribers.

After updating to `master`, I get a failure inside the `resubscribe()` function in `exometer_report` when it receives an interval name. This happens soon after exometer application is started.

I haven't been able to investigate the root of the issue, so in this PR I'm including a workaround that seems to alleviate this issue in our project. As far as I can tell, everything else works fine and all our metrics are being reported as before.

Cheers,
Alex