### PR TITLE
verify number type for histogram updates

### DIFF
--- a/src/exometer_histogram.erl
+++ b/src/exometer_histogram.erl
@@ -295,7 +295,12 @@ probe_setopts(_Entry, _Opts, _St)  ->
 probe_update(Value, ?OLDSTATE = St) ->
     probe_update(Value, convert(St));
 probe_update(Value, St) ->
-    {ok, update_int(exometer_util:timestamp(), Value, St)}.
+    if is_number(Value) ->
+	    {ok, update_int(exometer_util:timestamp(), Value, St)};
+       true ->
+	    %% ignore
+	    {ok, St}
+    end.
 
 update_int(Timestamp, Value, #st{slide = Slide,
 				 histogram_module = Module,


### PR DESCRIPTION
Updating a histogram metric entry would previously crash the histogram probe. The current change checks if the value is a number, and discards it otherwise.