### PR TITLE
Uw global status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,5 @@ clean_plt:
 	rm -f $(EXOMETER_PLT)
 
 dialyzer: deps compile $(EXOMETER_PLT)
-	dialyzer -r ebin --plt $(EXOMETER_PLT) $(DIALYZER_OPTS)
+	dialyzer -r ebin --plt $(EXOMETER_PLT) $(DIALYZER_OPTS) | \
+	fgrep -v -f ./dialyzer.ignore-warnings

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,2 @@
+exometer.erl:209: The variable _ can never match since previous clauses completely covered the type 'enabled'
+exometer.erl:444: The variable _ can never match since previous clauses completely covered the type 'enabled'

--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -60,6 +60,8 @@
     register_application/1
    ]).
 
+-export([global_status/1]).
+
 -export([create_entry/1]).  % called only from exometer_admin.erl
 
 %% Convenience function for testing
@@ -201,7 +203,13 @@ ensure(Name, Type, Opts) when is_list(Name), is_list(Opts) ->
 %% corresponding callback module will be called. For a disabled metric,
 %% `ok' will be returned without any other action being taken.
 %% @end
-update(Name, Value) when is_list(Name) ->
+update(Name, Value) ->
+    case exometer_global:status() of
+	enabled -> update_(Name, Value);
+	_ -> ok
+    end.
+
+update_(Name, Value) when is_list(Name) ->
     case ets:lookup(Table = exometer_util:table(), Name) of
         [#exometer_entry{status = Status} = E]
           when ?IS_ENABLED(Status) ->
@@ -430,7 +438,13 @@ sample(Name)  when is_list(Name) ->
 %% the exometer entry, which can be recalled using {@link info/2}, and will
 %% indicate the time that has passed since the metric was last reset.
 %% @end
-reset(Name)  when is_list(Name) ->
+reset(Name) ->
+    case exometer_global:status() of
+	enabled -> reset_(Name);
+	_ -> ok
+    end.
+
+reset_(Name)  when is_list(Name) ->
     case ets:lookup(exometer_util:table(), Name) of
         [#exometer_entry{status = Status} = E] when ?IS_ENABLED(Status) ->
             case E of
@@ -809,6 +823,28 @@ aggr_acc([{D,V}|T], Acc) ->
     end;
 aggr_acc([], Acc) ->
     Acc.
+
+global_status(St) when St==enabled; St==disabled ->
+    Prev = exometer_global:status(),
+    if St =:= Prev -> ok;
+       true ->
+	    parse_trans_mod:transform_module(
+	      exometer_global, fun(Forms,_) -> pt(Forms, St) end, [])
+    end,
+    Prev.
+
+pt(Forms, St) ->
+    parse_trans:plain_transform(
+      fun(F) ->
+	      plain_pt(F, St)
+      end, Forms).
+
+plain_pt({function, L, status, 0, [_]}, St) ->
+    {function, L, status, 0,
+     [{clause, L, [], [], [{atom, L, St}]}]};
+plain_pt(_, _) ->
+    continue.
+
 
 %% Perform variable replacement in the ets select pattern.
 %% We want to project the entries as a set of {Name, Type, Status} tuples.

--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -205,8 +205,8 @@ ensure(Name, Type, Opts) when is_list(Name), is_list(Opts) ->
 %% @end
 update(Name, Value) ->
     case exometer_global:status() of
-	enabled -> update_(Name, Value);
-	_ -> ok
+        enabled -> update_(Name, Value);
+        _ -> ok
     end.
 
 update_(Name, Value) when is_list(Name) ->
@@ -440,8 +440,8 @@ sample(Name)  when is_list(Name) ->
 %% @end
 reset(Name) ->
     case exometer_global:status() of
-	enabled -> reset_(Name);
-	_ -> ok
+        enabled -> reset_(Name);
+        _ -> ok
     end.
 
 reset_(Name)  when is_list(Name) ->
@@ -828,15 +828,15 @@ global_status(St) when St==enabled; St==disabled ->
     Prev = exometer_global:status(),
     if St =:= Prev -> ok;
        true ->
-	    parse_trans_mod:transform_module(
-	      exometer_global, fun(Forms,_) -> pt(Forms, St) end, [])
+            parse_trans_mod:transform_module(
+              exometer_global, fun(Forms,_) -> pt(Forms, St) end, [])
     end,
     Prev.
 
 pt(Forms, St) ->
     parse_trans:plain_transform(
       fun(F) ->
-	      plain_pt(F, St)
+              plain_pt(F, St)
       end, Forms).
 
 plain_pt({function, L, status, 0, [_]}, St) ->

--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -146,7 +146,7 @@ do_load_predef(Src, L) when is_list(L) ->
                    (Other) ->
                         lager:error("Predef(~p): ~p~n",
                                     [Src, {bad_pattern,Other}])
-		end, Found);
+                end, Found);
          ({aliases, Aliases}) ->
               lists:foreach(
                 fun({Alias, Entry, DP}) ->

--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -146,7 +146,12 @@ do_load_predef(Src, L) when is_list(L) ->
                    (Other) ->
                         lager:error("Predef(~p): ~p~n",
                                     [Src, {bad_pattern,Other}])
-                end, Found)
+		end, Found);
+         ({aliases, Aliases}) ->
+              lists:foreach(
+                fun({Alias, Entry, DP}) ->
+                        exometer_alias:new(Alias, Entry, DP)
+                end, Aliases)
       end, L).
 
 predef_delete_entry(Key, Src) ->

--- a/src/exometer_global.erl
+++ b/src/exometer_global.erl
@@ -2,6 +2,6 @@
 
 -export([status/0]).
 
-
+-spec status() -> enabled | disabled.
 status() ->
     enabled.

--- a/src/exometer_global.erl
+++ b/src/exometer_global.erl
@@ -1,0 +1,7 @@
+-module(exometer_global).
+
+-export([status/0]).
+
+
+status() ->
+    enabled.


### PR DESCRIPTION
Optimized method of disabling *all* stat updates.

The module `exometer_global` contains a hard-coded status() function that can be re-written at run-time by calling `exometer:global_status(enabled | disabled)`.