### PR TITLE
Add setup to the list of exometer_core applicatons

### DIFF
--- a/src/exometer_core.app.src
+++ b/src/exometer_core.app.src
@@ -8,7 +8,8 @@
    [
     kernel,
     stdlib,
-    lager
+    lager,
+    setup
    ]},
   {included_applications,
    [

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -119,18 +119,18 @@ init_per_testcase(Case, Config) when
       Case == test_ext_predef;
       Case == test_function_match ->
     ok = application:set_env(stdlib, exometer_predefined, {script, "../../test/data/test_defaults.script"}),
-    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
     [{started_apps, StartedApps} | Config];
 init_per_testcase(test_app_predef, Config) ->
     compile_app1(Config),
-    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
     Scr = filename:join(filename:dirname(
-			  filename:absname(?config(data_dir, Config))),
-			"data/app1.script"),
+                          filename:absname(?config(data_dir, Config))),
+                        "data/app1.script"),
     ok = application:set_env(app1, exometer_predefined, {script, Scr}),
     [{started_apps, StartedApps} | Config];
 init_per_testcase(_Case, Config) ->
-    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
     [{started_apps, StartedApps} | Config].
 
 end_per_testcase(Case, Config) when

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -111,50 +111,49 @@ init_per_testcase(Case, Config) when
       Case == test_folsom_histogram;
       Case == test_history1_folsom;
       Case == test_history4_folsom ->
+    {ok, StartedApps} = application:ensure_all_started(exometer_core),
     application:start(bear),
     application:start(folsom),
-    exometer:start(),
-    Config;
+    [{started_apps, StartedApps} | Config];
 init_per_testcase(Case, Config) when
       Case == test_ext_predef;
       Case == test_function_match ->
     ok = application:set_env(stdlib, exometer_predefined, {script, "../../test/data/test_defaults.script"}),
-    ok = application:start(setup),
-    exometer:start(),
-    Config;
+    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    [{started_apps, StartedApps} | Config];
 init_per_testcase(test_app_predef, Config) ->
     compile_app1(Config),
-    exometer:start(),
+    {ok, StartedApps} = application:ensure_all_started(exometer_core),
     Scr = filename:join(filename:dirname(
 			  filename:absname(?config(data_dir, Config))),
 			"data/app1.script"),
     ok = application:set_env(app1, exometer_predefined, {script, Scr}),
-    Config;
+    [{started_apps, StartedApps} | Config];
 init_per_testcase(_Case, Config) ->
-    exometer:start(),
-    Config.
+    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    [{started_apps, StartedApps} | Config].
 
-end_per_testcase(Case, _Config) when
+end_per_testcase(Case, Config) when
       Case == test_folsom_histogram;
       Case == test_history1_folsom;
       Case == test_history4_folsom ->
-    exometer:stop(),
+    [application:stop(App) || App <- ?config(started_apps, Config)],
     folsom:stop(),
     application:stop(bear),
     ok;
-end_per_testcase(Case, _Config) when
+end_per_testcase(Case, Config) when
       Case == test_ext_predef;
       Case == test_function_match ->
     ok = application:unset_env(common_test, exometer_predefined),
-    exometer:stop(),
+    [application:stop(App) || App <- ?config(started_apps, Config)],
     ok = application:stop(setup),
     ok;
-end_per_testcase(test_app_predef, _Config) ->
+end_per_testcase(test_app_predef, Config) ->
     ok = application:stop(app1),
-    exometer:stop(),
+    [application:stop(App) || App <- ?config(started_apps, Config)],
     ok;
-end_per_testcase(_Case, _Config) ->
-    exometer:stop(),
+end_per_testcase(_Case, Config) ->
+    [application:stop(App) || App <- ?config(started_apps, Config)],
     ok.
 
 %%%===================================================================

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -111,7 +111,7 @@ init_per_testcase(Case, Config) when
       Case == test_folsom_histogram;
       Case == test_history1_folsom;
       Case == test_history4_folsom ->
-    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
     application:start(bear),
     application:start(folsom),
     [{started_apps, StartedApps} | Config];

--- a/test/exometer_alias_SUITE.erl
+++ b/test/exometer_alias_SUITE.erl
@@ -68,11 +68,11 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(Case, Config) ->
-    exometer:start(),
-    Config.
+    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    [{started_apps, StartedApps} | Config].
 
 end_per_testcase(_Case, Config) ->
-    exometer:stop(),
+    [application:stop(App) || App <- ?config(started_apps, Config)],
     ok.
 
 %%%===================================================================

--- a/test/exometer_alias_SUITE.erl
+++ b/test/exometer_alias_SUITE.erl
@@ -68,7 +68,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(Case, Config) ->
-    {ok, StartedApps} = application:ensure_all_started(exometer_core),
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
     [{started_apps, StartedApps} | Config].
 
 end_per_testcase(_Case, Config) ->

--- a/test/exometer_test_util.erl
+++ b/test/exometer_test_util.erl
@@ -1,0 +1,34 @@
+-module(exometer_test_util).
+
+-export([ensure_all_started/1]).
+
+%% This implementation is originally from Basho's Webmachine. On
+%% older versions of Erlang, we don't have
+%% application:ensure_all_started, so we use this wrapper function to
+%% either use the native implementation or our own version, depending
+%% on what's available.
+-spec ensure_all_started(atom()) -> {ok, [atom()]} | {error, term()}.
+ensure_all_started(App) ->
+    case erlang:function_exported(application, ensure_all_started, 1) of
+        true ->
+            application:ensure_all_started(App);
+        false ->
+            ensure_all_started(App, [])
+    end.
+
+%% This implementation is originally from Basho's
+%% Webmachine. Reimplementation of ensure_all_started. NOTE this does
+%% not behave the same as the native version in all cases, but as a
+%% quick hack it works well enough for our purposes. Eventually I
+%% assume we'll drop support for older versions of Erlang and this can
+%% be eliminated.
+ensure_all_started(App, Apps0) ->
+    case application:start(App) of
+        ok ->
+            {ok, lists:reverse([App | Apps0])};
+        {error,{already_started,App}} ->
+            {ok, lists:reverse(Apps0)};
+        {error,{not_started,BaseApp}} ->
+            {ok, Apps} = ensure_all_started(BaseApp, Apps0),
+            ensure_all_started(App, [BaseApp|Apps])
+    end.


### PR DESCRIPTION
The setup application is required by exometer_core when it starts so add
it to the list of applications to ensure it is included in release
builds. This avoids applications that include exometer_core as a
dependency from having to explicitly list the setup application in a
release configuration.