### PR TITLE
Added exometer_report_logger and test suite

### DIFF
--- a/src/exometer_core_sup.erl
+++ b/src/exometer_core_sup.erl
@@ -35,10 +35,11 @@ start_link() ->
 
 init([]) ->
     Children0 = [
-                 ?CHILD(exometer_admin, worker),
-                 ?CHILD(exometer_cache, worker),
-                 ?CHILD(exometer_report, worker),
-                 ?CHILD(exometer_folsom_monitor, worker),
-                 ?CHILD(exometer_alias, worker)
-                ],
+		 ?CHILD(exometer_admin, worker),
+		 ?CHILD(exometer_cache, worker),
+		 ?CHILD(exometer_report, worker),
+		 ?CHILD(exometer_report_logger_sup, supervisor),
+		 ?CHILD(exometer_folsom_monitor, worker),
+		 ?CHILD(exometer_alias, worker)
+		],
     {ok, {{one_for_one, 5, 10}, Children0}}.

--- a/src/exometer_core_sup.erl
+++ b/src/exometer_core_sup.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2014-15 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %%   This Source Code Form is subject to the terms of the Mozilla Public
 %%   License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/exometer_report_logger.erl
+++ b/src/exometer_report_logger.erl
@@ -1,0 +1,427 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
+%% @doc Exometer report collector and logger.
+%%
+%% This module implements a behavior for collecting reporting data and
+%% handling it (logging to disk or ets, printing to tty, etc.)
+%%
+%% The logger has built-in support for receiving input via UDP, TCP or
+%% internal Erlang messaging, as well as a plugin API for custom input
+%% handling. Correspondingly, it has support for output to TTY or ets, as
+%% well as a plugin API for custom output.
+%%
+%% An example of how the logger can be used can be found in
+%% `test/exometer_test_udp_reporter.erl', which implements a UDP-based
+%% reporter as well as an input plugin and an output plugin. This reporter
+%% is used by `test/exometer_report_SUITE.erl'.
+%%
+%% Loggers can be combined, e.g. by creating one logger that receives Erlang
+%% messages, and other loggers that receive from different sources, prefix
+%% their reports and pass them on to the first logger.
+%%
+%% <h2>Input plugins</h2>
+%%
+%% An input plugin is initiated by `Module:logger_init_input(State)', where
+%% `State' is whatever was given as a `state' option (default: `undefined').
+%% The function must create a process and return `{ok, Pid}'. `Pid' is
+%% responsible for setting up whatever input channel is desired, and passes
+%% on incoming data to the logger via Erlang messages `{plugin, Pid, Data}'.
+%%
+%% <h2>Output Chaining</h2>
+%%
+%% Each incoming data item is passed through the list of output operators.
+%% Each output operator is able to modify the data (the `tty' and `ets'
+%% operators leave the data unchanged). Output plugins receive the data
+%% in `Module:logger_handle_data(Data, State)', which must return
+%% `{NewData, NewState}'. The state is private to the plugin, while `NewData'
+%% will be passed along to the next output operator.
+%%
+%% <h2>Flow control</h2>
+%%
+%% The logger will handle flow control automatically for `udp' and `tcp'
+%% inputs. If `{active,once}' or `{active, false}', the logger will trigger
+%% `{active, once}' each time it has handled an incoming message.
+%% If `{active, N}', it will "refill" the port each time it receives an
+%% indication that it has become passive.
+%%
+%% Input plugins create a process in `Module:logger_init_input/1'. This process
+%% can mimick the behavior of Erlang ports by sending a `{plugin_passive, Pid}'
+%% message to the logger. The logger will reply with a message,
+%% `{plugin_active, N}', where `N' is the value given by the `active' option.
+%% @end
+-module(exometer_report_logger).
+
+-behaviour(gen_server).
+
+-export([new/1]).
+-export([start_link/1]).
+
+-export([info/0,
+         info/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(st, {id,
+             input,
+             output}).
+
+-include_lib("parse_trans/include/exprecs.hrl").
+-export_records([tcp, udp, tty, ets, int]).
+
+%% input records
+-record(tcp, {socket, port, options = [], active = once}).
+-record(udp, {socket, port, options = [], active = true}).
+%% output records
+-record(tty, {prefix = []}).
+-record(ets, {tab}).
+%% both input and output
+-record(int, {process}).
+-record(plugin, {module, mod_state, process, active = once}).
+
+-type proplist() :: [{atom(), any()}].
+
+-type logger_info() :: {id, any()}
+                     | {input, proplist()}
+                     | {output, proplist()}.
+
+-type plugin_state() :: any().
+
+-callback logger_init_input(any()) ->
+    {ok, pid()}.
+-callback logger_init_output(any()) ->
+    {ok, plugin_state()}.
+-callback logger_handle_data(binary(), plugin_state()) ->
+    {binary(), plugin_state()}.
+
+-spec new([{id, any()} | {input, list()} | {output, list()}]) -> {ok,pid()}.
+%% @doc Create a new logger instance.
+%%
+%% This function creates a logger process with the given input and output
+%% parameters.
+%%
+%% * `{id, ID}' is mainly for documentation and simplifying identification
+%%   of instances returned by {@link info/0}.
+%% * `{input, PropList}' specifies what the logger listens to. Only the first
+%%   `input' entry is regarded, but the option is mandatory.
+%% * `{output, PropList}' specifies what the logger should to with received
+%%    data. Multiple `output' entries are allowed, and they will be processed
+%%    in the order given.
+%%
+%% Valid input options:
+%%
+%% * `{mode, udp | tcp | internal | plugin}' defines the protocol
+%% * `{active, false | true | once | N}' provides flow control. Default: `true'.
+%% * (mode-specific options)
+%%
+%% Valid output options:
+%%
+%% * `{mode, tty | ets | plugin | internal}' defines output types
+%% * (output-specific options)
+%%
+%% Mode-specific options, `udp':
+%%
+%% * `{port, integer()}' - UDP port number
+%% * `{options, list()}' - Options to pass to {@link gen_udp:open/2}
+%%
+%% Mode-specific options, `tcp':
+%%
+%% * `{port, integer()}' - TCP port number
+%% * `{options, list()}' - Options to pass to {@link gen_tcp:listen/2}
+%%
+%% Mode-specific options, `tty':
+%%
+%% * `{prefix, iolist()}' - Prefix string inserted before the data, which is
+%%   printed as-is (note that any delimiter would need to be part of the prefix)
+%%
+%% Mode-specific options, `ets':
+%% * `{table, ets:table()}' - Ets table identifier. If not specified, an
+%%    ordered-set table will be created by the logger process. The incoming
+%%    data will be inserted as `{erlang:now(), Data}'.
+%%
+%% Mode-specific options, `internal':
+%% * `{process, PidOrRegname}' specifies another logger instance, which is to
+%%   receive data from this logger (if used in output), or which is allowed
+%%   to send to this logger (if used in input). If no process is given for
+%%   input, any process can send data (on the form
+%%   `{exometer_report_logger, Pid, Data}') to this logger.
+%%
+%% Mode-specific options, `plugin':
+%%
+%% * `{module, Module}' - name of callback module
+%%    (behaviour: `exometer_report_logger')
+%% * `{state, State}' - Passed as initial argument to
+%%   `Module:logger_init_input/1' or `Module:logger_init_output/1', depending
+%%   on whether the plugin is specified as input or output.
+%% @end
+new(Options) ->
+    supervisor:start_child(exometer_report_logger_sup, [Options]).
+
+-spec start_link(proplist()) -> {ok, pid()}.
+%% @doc Start function for logger instance.
+%%
+%% This function is the start function eventually called as a result from
+%% {@link new/1}, but whereas `new/1' creates a supervised instance, this
+%% function simply creates the process. It would normally not be used directly.
+%% @end
+start_link(Options) ->
+    ID = exometer_util:get_opt(id, Options, undefined),
+    Input = get_input(Options),
+    Output = get_output(Options),
+    gen_server:start_link(?MODULE, {ID, Input, Output}, []).
+
+-spec info() -> [{pid(), [logger_info()]}].
+%% @doc List active logger instances.
+%%
+%% This function lists the instances started via {@link new/1}, along with their
+%% respective settings as nested property lists.
+%% @end
+info() ->
+    [{P, info(P)} || {_, P, _, _} <- supervisor:which_children(
+                                       exometer_report_logger_sup)].
+-spec info(pid()) -> [logger_info()].
+%% @doc Lists the settings of a given logger instance.
+info(P) ->
+    gen_server:call(P, info).
+
+%% Client-side check
+get_input(Opts) ->
+    L = exometer_util:get_opt(input, Opts),
+    get_input(exometer_util:get_opt(mode, L), L).
+
+get_input(tcp, L) ->
+    Port = exometer_util:get_opt(port, L),
+    Options = exometer_util:get_opt(options, L, []),
+    Active = exometer_util:get_opt(
+               active, L, get_opt_active(Options)),
+    #tcp{port = Port, options = Options, active = Active};
+get_input(udp, L) ->
+    Port = exometer_util:get_opt(port, L),
+    Options = exometer_util:get_opt(options, L, []),
+    Active = exometer_util:get_opt(
+               active, L, get_opt_active(Options)),
+    #udp{port = Port, options = Options, active = Active};
+get_input(internal, L) ->
+    P = exometer_util:get_opt(process, L, undefined),
+    #int{process = P};
+get_input(plugin, L) ->
+    Mod = exometer_util:get_opt(module, L),
+    St  = exometer_util:get_opt(state, L, undefined),
+    Active = exometer_util:get_opt(active, L, true),
+    #plugin{module = Mod, mod_state = St, active = Active}.
+
+
+get_opt_active(Opts) ->
+    case lists:keyfind(active, 1, Opts) of
+        {_, true} -> true;
+        {_, N} when is_integer(N) -> N;
+        _ -> once
+    end.
+
+%% Client-side check
+get_output(Opts) ->
+    [get_output(exometer_util:get_opt(mode, O), O) || {output, O} <- Opts].
+
+get_output(tty, O) ->
+    Prefix = exometer_util:get_opt(prefix, O, []),
+    #tty{prefix = Prefix};
+get_output(ets, O) ->
+    Tab = exometer_util:get_opt(tab, O, undefined),
+    #ets{tab = Tab};
+get_output(internal, O) ->
+    P = exometer_util:get_opt(process, O),
+    #int{process = P};
+get_output(plugin, O) ->
+    Mod = exometer_util:get_opt(module, O),
+    St  = exometer_util:get_opt(state, O, undefined),
+    #plugin{module = Mod, mod_state = St}.
+
+
+%% Gen_server callbacks
+
+%% @private
+init({ID, Input, Output}) ->
+    NewL = init_input(Input),
+    NewO = init_output(Output),
+    {ok, #st{id = ID,
+             input = NewL,
+             output = NewO}}.
+
+%% @private
+handle_call(info, _, #st{id = ID, input = I, output = O} = S) ->
+    {reply, info_(ID, I, O), S};
+handle_call(_Req, _From, St) ->
+    {reply, {error, unsupported}, St}.
+
+%% @private
+handle_cast({socket, Socket}, #st{input = L} = S) ->
+    case L of
+        #tcp{active = N} = T ->
+            case inet:getopts(Socket, [active]) of
+                [false] ->
+                    inet:setopts(Socket, {active, N});
+                _ ->
+                    ok
+            end,
+            {noreply, S#st{input = T#tcp{socket = Socket}}};
+        _ ->
+            {noreply, S}
+    end;
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+%% @private
+handle_info({tcp, Socket, Data}, #st{input = #tcp{socket = Socket,
+                                                  active = Active},
+                                     output = Out} = S) ->
+    handle_data(Data, Out),
+    check_active(Socket, Active),
+    {noreply, S};
+handle_info({udp, Socket, _Host, _Port, Data},
+            #st{input = #udp{socket = Socket}, output = Out} = S) ->
+    Out1 = handle_data(Data, Out),
+    {noreply, S#st{output = Out1}};
+handle_info({plugin, Pid, Data}, #st{input = #plugin{process = Pid},
+                                     output = Out} = S) ->
+    Out1 = handle_data(Data, Out),
+    {noreply, S#st{output = Out1}};
+handle_info({tcp_passive, Socket}, #st{input = #tcp{socket = Socket,
+                                                    active = Active}} = S) ->
+    inet:setopts(Socket, Active),
+    {noreply, S};
+handle_info({udp_passive, Socket}, #st{input = #udp{socket = Socket,
+                                                    active = Active}} = S) ->
+    inet:setopts(Socket, Active),
+    {noreply, S};
+handle_info({plugin_passive, Pid}, #st{input = #plugin{process = Pid,
+                                                       active = Active}} = S) ->
+    Pid ! {plugin_active, Active},
+    {noreply, S};
+handle_info({?MODULE, P, Data}, #st{input = #int{process = Pl},
+                                    output = Out} = S)
+  when Pl =:= P; Pl =:= undefined ->
+    Out1 = handle_data(Data, Out),
+    {noreply, S#st{output = Out1}};
+handle_info(_, S) ->
+    {noreply, S}.
+
+%% @private
+terminate(_, _) ->
+    ok.
+
+%% @private
+code_change(_FromVsn, S, _Extra) ->
+    {ok, S}.
+
+%% End gen_server callbacks
+
+info_(ID, I, O) ->
+    [{id, ID},
+     {input, ensure_list(pp(I))},
+     {output, ensure_list(pp(O))}].
+
+ensure_list(I) when is_tuple(I) ->
+    [I];
+ensure_list(I) when is_list(I) ->
+    I.
+
+%% Copied from git:uwiger/jobs/src/jobs_info.erl
+pp(L) when is_list(L) ->
+    [pp(X) || X <- L];
+pp(X) ->
+    case '#is_record-'(X) of
+        true ->
+            RecName = element(1,X),
+            {RecName, lists:zip(
+                        '#info-'(RecName,fields),
+                        pp(tl(tuple_to_list(X))))};
+        false ->
+            if is_tuple(X) ->
+                    list_to_tuple(pp(tuple_to_list(X)));
+               true ->
+                    X
+            end
+    end.
+
+init_input(#tcp{port = Port,
+                options = Opts} = T) ->
+    _ = spawn_tcp_acceptor(Port, Opts),
+    T;
+init_input(#udp{port = Port, options = Opts} = U) ->
+    {ok, Socket} = gen_udp:open(Port, Opts),
+    U#udp{socket = Socket};
+init_input(#plugin{module = Mod, mod_state = St} = P) ->
+    case Mod:logger_init_input(St) of
+        {ok, Pid} when is_pid(Pid) ->
+            P#plugin{process = Pid}
+    end;
+init_input(#int{} = I) ->
+    I.
+
+
+spawn_tcp_acceptor(Port, Opts) ->
+    Parent = self(),
+    spawn_link(fun() ->
+                       {ok, LSock} = gen_tcp:listen(Port, Opts),
+                       {ok, Socket} = gen_tcp:accept(LSock),
+                       ok = gen_tcp:controlling_process(Socket, Parent),
+                       gen_server:cast(Parent, {socket, Socket})
+               end).
+
+init_output(Out) ->
+    [init_output_(O) || O <- Out].
+
+init_output_(#tty{} = TTY) -> TTY;
+init_output_(#int{} = Int) -> Int;
+init_output_(#ets{tab = T} = E) ->
+    Tab = case T of
+              undefined ->
+                  ets:new(?MODULE, [ordered_set]);
+              _ ->
+                  T
+          end,
+    E#ets{tab = Tab};
+init_output_(#plugin{module = Mod, mod_state = St} = P) ->
+    {ok, St1} = Mod:logger_init_output(St),
+    P#plugin{mod_state = St1}.
+
+check_active(Socket, once) ->
+    inet:setopts(Socket, [{active, once}]);
+check_active(_Socket, _) ->
+    ok.
+
+handle_data(Data, Out) ->
+    handle_data(Data, Out, []).
+
+handle_data(Data, [H|T], Acc) ->
+    {Data1, H1} = handle_data_(Data, H),
+    handle_data(Data1, T, [H1|Acc]);
+handle_data(_, [], Acc) ->
+    lists:reverse(Acc).
+
+handle_data_(Data, #tty{prefix = Pfx} = Out) ->
+    io:fwrite(iolist_to_binary([Pfx, Data, $\n])),
+    {Data, Out};
+handle_data_(Data, #ets{tab = T} = Out) ->
+    ets:insert(T, {erlang:now(), Data}),
+    {Data, Out};
+handle_data_(Data, #int{process = P} = Out) ->
+    try P ! {?MODULE, self(), Data} catch _:_ -> error end,
+    {Data, Out};
+handle_data_(Data, #plugin{module = Mod, mod_state = ModSt} = Out) ->
+    {Data1, ModSt1} = Mod:logger_handle_data(Data, ModSt),
+    {Data1, Out#plugin{mod_state = ModSt1}}.
+
+
+

--- a/src/exometer_report_logger.erl
+++ b/src/exometer_report_logger.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %%   This Source Code Form is subject to the terms of the Mozilla Public
 %%   License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/exometer_report_logger_sup.erl
+++ b/src/exometer_report_logger_sup.erl
@@ -1,0 +1,26 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
+-module(exometer_report_logger_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+start_link() ->
+    supervisor:start_link({local,?MODULE}, ?MODULE, []).
+
+
+init(_) ->
+    {ok, {{simple_one_for_one, 3, 10},
+          [?CHILD(exometer_report_logger, worker)]}}.

--- a/src/exometer_report_logger_sup.erl
+++ b/src/exometer_report_logger_sup.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %%   This Source Code Form is subject to the terms of the Mozilla Public
 %%   License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -15,6 +15,7 @@
    [
     timestamp/0,
     timestamp_to_datetime/1,
+    get_opt/2,
     get_opt/3,
     get_env/2,
     tables/0,
@@ -89,6 +90,13 @@ get_env1(App, Key) ->
     case application:get_env(App, Key) of
         {ok, undefined} -> undefined;
         Other           -> Other
+    end.
+
+get_opt(K, Opts) ->
+    case lists:keyfind(K, 1, Opts) of
+        {_, V} -> V;
+        false ->
+            error({required, K})
     end.
 
 get_opt(K, Opts, Default) ->

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -120,10 +120,12 @@ init_per_testcase(Case, Config) when
       Case == test_function_match ->
     ok = application:set_env(stdlib, exometer_predefined, {script, "../../test/data/test_defaults.script"}),
     {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
+    ct:log("StartedApps = ~p~n", [StartedApps]),
     [{started_apps, StartedApps} | Config];
 init_per_testcase(test_app_predef, Config) ->
     compile_app1(Config),
     {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
+    ct:log("StartedApps = ~p~n", [StartedApps]),
     Scr = filename:join(filename:dirname(
                           filename:absname(?config(data_dir, Config))),
                         "data/app1.script"),
@@ -131,13 +133,14 @@ init_per_testcase(test_app_predef, Config) ->
     [{started_apps, StartedApps} | Config];
 init_per_testcase(_Case, Config) ->
     {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
+    ct:log("StartedApps = ~p~n", [StartedApps]),
     [{started_apps, StartedApps} | Config].
 
 end_per_testcase(Case, Config) when
       Case == test_folsom_histogram;
       Case == test_history1_folsom;
       Case == test_history4_folsom ->
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    stop_started_apps(Config),
     folsom:stop(),
     application:stop(bear),
     ok;
@@ -145,16 +148,20 @@ end_per_testcase(Case, Config) when
       Case == test_ext_predef;
       Case == test_function_match ->
     ok = application:unset_env(common_test, exometer_predefined),
-    [application:stop(App) || App <- ?config(started_apps, Config)],
     ok = application:stop(setup),
+    stop_started_apps(Config),
     ok;
 end_per_testcase(test_app_predef, Config) ->
     ok = application:stop(app1),
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    stop_started_apps(Config),
     ok;
 end_per_testcase(_Case, Config) ->
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    stop_started_apps(Config),
     ok.
+
+stop_started_apps(Config) ->
+    [application:stop(App) ||
+        App <- lists:reverse(?config(started_apps, Config))].
 
 %%%===================================================================
 %%% Test Cases

--- a/test/exometer_report_SUITE.erl
+++ b/test/exometer_report_SUITE.erl
@@ -1,0 +1,192 @@
+-module(exometer_report_SUITE).
+
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
+%% common_test exports
+-export(
+   [
+    all/0, groups/0, suite/0,
+    init_per_suite/1, end_per_suite/1,
+    init_per_testcase/2, end_per_testcase/2
+   ]).
+
+%% test case exports
+-export(
+   [
+    test_newentry/1,
+    test_subscribe/1,
+    test_subscribe_find/1,
+    test_subscribe_select/1
+   ]).
+
+-behaviour(exometer_report_logger).
+-export([logger_init_output/1,
+         logger_handle_data/2]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exometer_core/include/exometer.hrl").
+
+-define(DEFAULT_PORT, 8888).
+
+all() ->
+    [
+     {group, test_reporter}
+    ].
+
+groups() ->
+    [
+     {test_reporter, [shuffle],
+      [
+       test_newentry,
+       test_subscribe,
+       test_subscribe_find,
+       test_subscribe_select
+      ]}
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    {ok, StartedApps} = exometer_test_util:ensure_all_started(exometer_core),
+    [{started_apps, StartedApps} | Config].
+
+end_per_testcase(_Case, Config) ->
+    stop_started_apps(Config).
+
+end_per_suite(_Config) ->
+    ok.
+
+stop_started_apps(Config) ->
+    [application:stop(App) ||
+        App <- lists:reverse(?config(started_apps, Config))].
+
+test_newentry(Config) ->
+    {ok, Info} = start_logger_and_reporter(test_udp, Config),
+    Tab = ets_tab(Info),
+    [] = ets:tab2list(Tab),
+    exometer:new([c], counter, []),
+    %% exometer_report:trigger_interval(test_udp, main),
+    R1 = check_logger_msg(),
+    [{_,{newentry,#exometer_entry{name = [c], type = counter}} = R1}] =
+        ets:tab2list(Tab),
+    ok.
+
+test_subscribe(Config) ->
+    ok = exometer:new([c], counter, []),
+    {ok, _Info} = start_logger_and_reporter(test_udp, Config),
+    exometer_report:subscribe(test_udp, [c], value, main, true),
+    %% exometer_report:trigger_interval(test_udp, main),
+    {subscribe, [{metric, [c]},
+                 {datapoint, value} | _]} = check_logger_msg(),
+    ok.
+
+test_subscribe_find(Config) ->
+    ok = exometer:new([c,1], counter, []),
+    ok = exometer:new([c,2], counter, []),
+    {ok, Info} = start_logger_and_reporter(test_udp, Config),
+    exometer_report:subscribe(test_udp, {find,[c,'_']}, value, main, true),
+    {subscribe, [{metric, {find,[c,'_']}},
+                 {datapoint, value} | _]} = R1 = check_logger_msg(),
+    exometer_report:trigger_interval(test_udp, main),
+    {report, [{prefix,[]},{metric,[c,1]}|_]} = R2 = check_logger_msg(),
+    {report, [{prefix,[]},{metric,[c,2]}|_]} = R3 = check_logger_msg(),
+    Tab = ets_tab(Info),
+    [{_,R1},{_,R2},{_,R3}] = ets:tab2list(Tab),
+    ok.
+
+test_subscribe_select(Config) ->
+    ok = exometer:new([c,1], counter, []),
+    ok = exometer:new([c,2], counter, []),
+    ok = exometer:new([c,3], counter, []),
+    {ok, Info} = start_logger_and_reporter(test_udp, Config),
+    exometer_report:subscribe(
+      test_udp,
+      {select,[{ {[c,'$1'],'_','_'},[{'<','$1',3}], ['$_'] }]},
+      value, main, true),
+    {subscribe, [{metric, {select,_}},
+                 {datapoint, value} | _]} = R1 = check_logger_msg(),
+    exometer_report:trigger_interval(test_udp, main),
+    {report, [{prefix,[]},{metric,[c,1]}|_]} = R2 = check_logger_msg(),
+    {report, [{prefix,[]},{metric,[c,2]}|_]} = R3 = check_logger_msg(),
+    Tab = ets_tab(Info),
+    [{_,R1},{_,R2},{_,R3}] = ets:tab2list(Tab),
+    ok.
+
+
+start_logger_and_reporter(Reporter, Config) ->
+    Port = get_port(Config),
+    Res = exometer_report_logger:new(
+            [{id, ?MODULE},
+             {input, [{mode, plugin},
+                      {module, exometer_test_udp_reporter},
+                      {state, {Port, []}}]},
+             {output, [{mode, plugin},
+                       {module, exometer_test_udp_reporter}]},
+             {output, [{mode, ets}]},
+             {output, [{mode, plugin},
+                       {module, ?MODULE},
+                       {state, self()}]}]),
+    ct:log("Logger start: ~p~n", [Res]),
+    Info = exometer_report_logger:info(),
+    ct:log("Logger Info = ~p~n", [Info]),
+    ok = exometer_report:add_reporter(
+           Reporter,
+           [{module, exometer_test_udp_reporter},
+            {hostname, "localhost"},
+            {port, Port},
+            {intervals, [{main, manual}]}]),
+    {ok, Info}.
+
+check_logger_msg() ->
+    receive
+        {logger_got, Data} ->
+            ct:log("logger_got: ~p~n", [Data]),
+            Data
+    after 1000 ->
+            error(logger_ack_timeout)
+    end.
+
+ets_tab(Info) ->
+    [T] = [tree_opt([output,ets,tab], I) || {_,[{id,?MODULE}|I]} <- Info],
+    T.
+
+get_port(Config) ->
+    case ?config(port, Config) of
+        undefined ->
+            ?DEFAULT_PORT;
+        Port ->
+            Port
+    end.
+
+tree_opt([H|T], L) when is_list(L) ->
+    case lists:keyfind(H, 1, L) of
+        {_, Val} ->
+            case T of
+                [] -> Val;
+                [_|_] ->
+                    tree_opt(T, Val)
+            end;
+        false ->
+            undefined
+    end;
+tree_opt([], _) ->
+    undefined.
+
+
+logger_init_output(Pid) ->
+    {ok, Pid}.
+
+logger_handle_data(Data, Pid) ->
+    Pid ! {logger_got, Data},
+    {Data, Pid}.

--- a/test/exometer_report_SUITE.erl
+++ b/test/exometer_report_SUITE.erl
@@ -1,14 +1,14 @@
--module(exometer_report_SUITE).
-
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %%   This Source Code Form is subject to the terms of the Mozilla Public
 %%   License, v. 2.0. If a copy of the MPL was not distributed with this
 %%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 %%
 %% -------------------------------------------------------------------
+-module(exometer_report_SUITE).
+
 %% common_test exports
 -export(
    [

--- a/test/exometer_test_udp_reporter.erl
+++ b/test/exometer_test_udp_reporter.erl
@@ -1,0 +1,118 @@
+-module(exometer_test_udp_reporter).
+
+-behaviour(exometer_report).
+-export(
+   [
+    exometer_init/1,
+    exometer_info/2,
+    exometer_cast/2,
+    exometer_call/3,
+    exometer_report/5,
+    exometer_subscribe/5,
+    exometer_unsubscribe/4,
+    exometer_newentry/2,
+    exometer_setopts/4,
+    exometer_terminate/2
+   ]).
+
+-behaviour(exometer_report_logger).
+-export([
+         logger_init_input/1,
+         logger_init_output/1,
+         logger_handle_data/2
+        ]).
+
+-import(exometer_util, [get_opt/2, get_opt/3]).
+
+-include_lib("kernel/include/inet.hrl").
+-record(st, {socket, address, port, type_map, prefix = []}).
+
+-define(DEFAULT_HOST, "localhost").
+
+exometer_init(Opts) ->
+    Port = get_opt(port, Opts),
+    {ok, Host} = inet:gethostbyname(get_opt(hostname, Opts, ?DEFAULT_HOST)),
+    [Addr|_] = Host#hostent.h_addr_list,
+    AddrType = Host#hostent.h_addrtype,
+    TypeMap = get_opt(type_map, Opts, []),
+    Prefix = get_opt(prefix, Opts, []),
+    case gen_udp:open(0, [AddrType]) of
+        {ok, Socket} ->
+            {ok, #st{socket = Socket, address = Addr, port = Port,
+                     type_map = TypeMap, prefix = Prefix}};
+        {error, _} = Error ->
+            Error
+    end.
+
+exometer_report(Metric, DataPoint, Extra, Value, #st{type_map = TypeMap,
+                                                     prefix = Pfx} = St) ->
+    RptType = exometer_util:report_type({Metric,DataPoint}, Extra, TypeMap),
+    ok = send({report, [{prefix, Pfx},
+                        {metric, Metric},
+                        {datapoint, DataPoint},
+                        {extra, Extra},
+                        {report_type, RptType},
+                        {value, Value}]}, St),
+    {ok, St}.
+
+exometer_subscribe(Metric, DataPoint, Extra, Interval, St) ->
+    ok = send({subscribe, [{metric, Metric},
+                           {datapoint, DataPoint},
+                           {extra, Extra},
+                           {interval, Interval}]}, St),
+    {ok, St}.
+
+exometer_unsubscribe(Metric, DataPoint, Extra, St) ->
+    ok = send({unsubscribe, [{metric, Metric},
+                             {datapoint, DataPoint},
+                             {extra, Extra}]}, St),
+    {ok, St}.
+
+exometer_call(Req, From, St) ->
+    ok = send({call, Req, From}, St),
+    {reply, {test_reply, ok}, St}.
+
+exometer_cast(Cast, St) ->
+    ok = send({cast, Cast}, St),
+    {ok, St}.
+
+exometer_info(I, St) ->
+    ok = send({info, I}, St),
+    {ok, St}.
+
+exometer_newentry(E, St) ->
+    ok = send({newentry, E}, St),
+    {ok, St}.
+
+exometer_setopts(Metric, Opts, Status, St) ->
+    ok = send({setopts, [{metric, Metric},
+                         {options, Opts},
+                         {status, Status}]}, St),
+    {ok, St}.
+
+exometer_terminate(_, _) ->
+    ok.
+
+send(Term, #st{socket = Socket, address = Address, port = Port}) ->
+    gen_udp:send(Socket, Address, Port, term_to_binary(Term, [compressed])).
+
+
+logger_init_input({Port, Opts}) ->
+    Parent = self(),
+    {ok, spawn_link(fun() ->
+                            {ok, Socket} = gen_udp:open(Port, [binary|Opts]),
+                            input_loop(Socket, Parent)
+                    end)}.
+
+logger_init_output(_) ->
+    {ok, []}.
+
+logger_handle_data(Data, St) ->
+    {binary_to_term(iolist_to_binary([Data])), St}.
+
+input_loop(Socket, Parent) ->
+    receive
+        {udp, Socket, _Host, _Port, Data} ->
+            Parent ! {plugin, self(), Data}
+    end,
+    input_loop(Socket, Parent).

--- a/test/exometer_test_udp_reporter.erl
+++ b/test/exometer_test_udp_reporter.erl
@@ -1,3 +1,12 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
 -module(exometer_test_udp_reporter).
 
 -behaviour(exometer_report).


### PR DESCRIPTION
The report logger was primarily created as a means to automate testing of reporters, but it should also be useful for ad-hoc testing of reporters during development, as well as perhaps creating custom report logging solutions.

Example:
```erlang
Eshell V5.10.3  (abort with ^G)
1> application:ensure_all_started(exometer_core).
...
{ok,[syntax_tools,compiler,goldrush,lager,setup,exometer_core]}
2> exometer_report_logger:new([{input,[{mode,udp},{port,8888}]},{output,[{mode,tty},{prefix,"statsd."}]}]).
{ok,<0.81.0>}
3> exometer_report_logger:info().
[{<0.81.0>,
  [{id,undefined},
   {input,[{udp,[{socket,#Port<0.3547>},
                 {port,8888},
                 {options,[]},
                 {active,once}]}]},
   {output,[{tty,[{prefix,"statsd."}]}]}]}]
4> exometer_report:add_reporter(statsd,[{module,exometer_report_statsd},{hostname,"localhost"},{port,8888}]).
ok
5> 16:57:32.808 [info] exometer_report_statsd([{module,exometer_report_statsd},{hostname,"localhost"},{port,8888}]): Starting

5> exometer:new([g], gauge, []).
ok
6> exometer_report:subscribe(statsd, [g], value, 1000, true).
ok
7> statsd.g.value:0|g
statsd.g.value:0|g
statsd.g.value:0|g
statsd.g.value:0|g
statsd.g.value:0|g
statsd.g.value:0|g
statsd.g.value:0|g
```

For a more advanced example, see [exometer_report_SUITE.erl](https://github.com/Feuerlabs/exometer_core/blob/uw-report-logger/test/exometer_report_SUITE.erl) and [exometer_test_udp_reporter.erl](https://github.com/Feuerlabs/exometer_core/blob/uw-report-logger/test/exometer_test_udp_reporter.erl).