### PR TITLE
Repaired and extended probe supervision

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,8 @@
     "https://github.com/Feuerlabs/exometer_core", "master"}}
  ]}.
 
+{ct_extra_params, "-config test/ct.config"}.
+
 {xref_checks,
  [
   undefined_function_calls,

--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -568,7 +568,7 @@ module_setopts(#exometer_entry{behaviour = probe,
                     {ok, Ref} = exometer_probe:start_probe(E),
                     update_entry_elems(Name, [{#exometer_entry.ref, Ref}])
             end;
-        false ->
+        _ ->
             exometer_probe:setopts(E, Options, NewStatus)
     end,
     ok;

--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -92,8 +92,8 @@
 
 %% @doc Start exometer and dependent apps (for testing).
 start() ->
-    lager:start(),
-    application:start(exometer_core).
+    {ok,_} = exometer_util:ensure_all_started(exometer_core),
+    ok.
 
 %% @doc Stop exometer and dependent apps (for testing).
 stop() ->
@@ -550,9 +550,28 @@ setopts(Name, Options) when is_list(Name), is_list(Options) ->
             {error, not_found}
     end.
 
-module_setopts(#exometer_entry{behaviour = probe}=E, Options, NewStatus) ->
+module_setopts(#exometer_entry{behaviour = probe,
+                               name = Name,
+                               status = St0} = E, Options, NewStatus) ->
     reporter_setopts(E, Options, NewStatus),
-    exometer_probe:setopts(E, Options, NewStatus);
+    case NewStatus of
+        disabled when ?IS_ENABLED(St0) ->
+            exometer_cache:delete_name(Name),
+            exometer_probe:stop_probe(E),
+            update_entry_elems(Name, [{#exometer_entry.ref, undefined}]);
+        enabled when ?IS_DISABLED(St0) ->
+            %% Previously, probes were not stopped when disabled
+            OldRef = E#exometer_entry.ref,
+            case is_pid(OldRef) andalso is_process_alive(OldRef) of
+                true -> ok;
+                false ->
+                    {ok, Ref} = exometer_probe:start_probe(E),
+                    update_entry_elems(Name, [{#exometer_entry.ref, Ref}])
+            end;
+        false ->
+            exometer_probe:setopts(E, Options, NewStatus)
+    end,
+    ok;
 
 module_setopts(#exometer_entry{behaviour = entry,
                                module=M} = E, Options, NewStatus) ->
@@ -565,8 +584,8 @@ module_setopts(#exometer_entry{behaviour = entry,
                 ok ->
                     reporter_setopts(E, Options, NewStatus),
                     ok;
-                E ->
-                    E
+                {error,_} = Error ->
+                    Error
             end
     end.
 
@@ -1129,11 +1148,18 @@ create_entry(#exometer_entry{module = exometer,
 create_entry(#exometer_entry{module = Module,
                              type = Type,
                              name = Name,
+                             status = Status,
                              options = Opts} = E) ->
     case
         case Module:behaviour() of
             probe ->
-                {probe, exometer_probe:new(Name, Type, [{ arg, Module} | Opts ]) };
+                if ?IS_ENABLED(Status) ->
+                        {probe, exometer_probe:new(
+                                  Name, Type, [{ arg, Module} | Opts ])};
+                   ?IS_DISABLED(Status) ->
+                        %% Don't start probe if disabled
+                        {probe, ok}
+                end;
             entry ->
                 {entry, Module:new(Name, Type, Opts) };
 

--- a/src/exometer_alias.erl
+++ b/src/exometer_alias.erl
@@ -25,6 +25,7 @@
 -export([new/3,
          load/1,
          unload/1,
+         check_map/1,
          delete/1,
          update/2,
          resolve/1,

--- a/src/exometer_cache.erl
+++ b/src/exometer_cache.erl
@@ -16,7 +16,8 @@
 -export([read/2,   %% (Name, DataPoint) -> {ok, Value} | not_found
          write/3,  %% (Name, DataPoint, Value) -> ok
          write/4,  %% (Name, DataPoint, Value, TTL) -> ok
-         delete/2
+         delete/2,
+         delete_name/1
         ]).
 
 -export([init/1,
@@ -62,6 +63,14 @@ write(Name, DataPoint, Value, TTL) ->
 delete(Name, DataPoint) ->
     %% Cancel the timer?
     ets:delete(?TABLE, path(Name, DataPoint)).
+
+delete_name(Name) ->
+    %% This function currently doesn't cancel any timers. The cost of doing
+    %% so would outweigh the cost of reacting to any timers that happen to
+    %% fire (timer-based cleanup matches on TRef, so will not accidentally
+    %% delete the wrong entries.)
+    ets:match_delete(?TABLE, #cache{name = {Name,'_'}, _ = '_'}),
+    ok.
 
 start_timer(Name, TTL, TS) ->
     gen_server:cast(?MODULE, {start_timer, Name, TTL, TS}).

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -369,12 +369,9 @@ test_event_flag(update, _) -> false.
 %% on what's available.
 -spec ensure_all_started(atom()) -> {ok, [atom()]} | {error, term()}.
 ensure_all_started(App) ->
-    case erlang:function_exported(application, ensure_all_started, 1) of
-        true ->
-            application:ensure_all_started(App);
-        false ->
-            ensure_all_started(App, [])
-    end.
+    %% Referencing application:ensure_all_started/1 will anger Xref
+    %% in earlier R16B versions of OTP
+    ensure_all_started(App, []).
 
 %% This implementation is originally from Basho's
 %% Webmachine. Reimplementation of ensure_all_started. NOTE this does

--- a/test/ct.config
+++ b/test/ct.config
@@ -1,0 +1,8 @@
+%% -*- erlang -*-
+{lager, [
+  {handlers, [
+    {lager_console_backend, debug},
+    {lager_file_backend, [{file, "error.log"}, {level, error}]},
+    {lager_file_backend, [{file, "console.log"}, {level, debug}]}
+  ]}
+]}.

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -159,9 +159,15 @@ end_per_testcase(_Case, Config) ->
     ok.
 
 stop_started_apps(Config) ->
-    [ok = application:stop(App) ||
+    [stop_app(App) ||
         App <- lists:reverse(?config(started_apps, Config))].
 
+stop_app(App) ->
+    case application:stop(App) of
+        ok -> ok;
+        {error, {not_started, _}} ->
+            ok
+    end.
 
 %%%===================================================================
 %%% Test Cases

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -139,24 +139,29 @@ end_per_testcase(Case, Config) when
       Case == test_folsom_histogram;
       Case == test_history1_folsom;
       Case == test_history4_folsom ->
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    _ = stop_started_apps(Config),
     folsom:stop(),
     application:stop(bear),
     ok;
 end_per_testcase(Case, Config) when
       Case == test_ext_predef;
       Case == test_function_match ->
-    ok = application:unset_env(common_test, exometer_predefined),
-    [application:stop(App) || App <- ?config(started_apps, Config)],
-    ok = application:stop(setup),
+    ok = application:unset_env(stdlib, exometer_predefined),
+    _ = stop_started_apps(Config),
     ok;
 end_per_testcase(test_app_predef, Config) ->
+    ok = application:unset_env(app1, exometer_predefined),
     ok = application:stop(app1),
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    _ = stop_started_apps(Config),
     ok;
 end_per_testcase(_Case, Config) ->
-    [application:stop(App) || App <- ?config(started_apps, Config)],
+    _ = stop_started_apps(Config),
     ok.
+
+stop_started_apps(Config) ->
+    [ok = application:stop(App) ||
+        App <- lists:reverse(?config(started_apps, Config))].
+
 
 %%%===================================================================
 %%% Test Cases

--- a/test/exometer_error_SUITE.erl
+++ b/test/exometer_error_SUITE.erl
@@ -1,0 +1,155 @@
+-module(exometer_error_SUITE).
+
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
+%% common_test exports
+-export(
+   [
+    all/0, groups/0, suite/0,
+    init_per_suite/1, end_per_suite/1,
+    init_per_testcase/2, end_per_testcase/2
+   ]).
+
+%% test case exports
+-export(
+   [
+    test_failing_probe/1,
+    test_escalation_1/1,
+    test_escalation_2/1
+   ]).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%%===================================================================
+%%% common_test API
+%%%===================================================================
+
+all() ->
+    [
+     {group, test_probes}
+    ].
+
+groups() ->
+    [
+     {test_probes, [shuffle],
+      [
+       test_failing_probe,
+       test_escalation_1,
+       test_escalation_2
+      ]}
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    _ = application:stop(exometer_core),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(Case, Config) ->
+    {ok, Started} = exometer_test_util:ensure_all_started(exometer_core),
+    ct:log("Started: ~p~n", [[{T, catch ets:tab2list(T)}
+                              || T <- exometer_util:tables()]]),
+    [{started_apps, Started}|Config].
+
+end_per_testcase(_Case, Config) ->
+    ct:log("end_per_testcase(Config = ~p)~n", [Config]),
+    stop_started_apps(Config),
+    ok.
+
+stop_started_apps(Config) ->
+    [application:stop(A) || A <- lists:reverse(?config(started_apps, Config))],
+    ok.
+
+%%%===================================================================
+%%% Test Cases
+%%%===================================================================
+test_failing_probe(_Config) ->
+    M = [?MODULE, ?LINE],
+    ok = exometer:new(M, histogram, []),
+    true = killed_probe_restarts(M),
+    ok.
+
+test_escalation_1(_Config) ->
+    M = [?MODULE, ?LINE],
+    Levels = [{{3,5000}, restart},
+              {'_', disable}],
+    ok = exometer:new(M, histogram, [{restart, Levels}]),
+    true = killed_probe_restarts(M),
+    true = killed_probe_restarts(M),
+    true = killed_probe_restarts(M),
+    true = killed_probe_disabled(M),
+    ok.
+
+test_escalation_2(_Config) ->
+    M = [?MODULE, ?LINE],
+    Levels = [{{3,5000}, restart},
+              {'_', delete}],
+    ok = exometer:new(M, histogram, [{restart, Levels}]),
+    true = killed_probe_restarts(M),
+    true = killed_probe_restarts(M),
+    true = killed_probe_restarts(M),
+    true = killed_probe_deleted(M),
+    ok.
+
+killed_probe_restarts(M) ->
+    Pid = exometer:info(M, ref),
+    ct:log("Pid = ~p~n", [Pid]),
+    exit(Pid, kill),
+    ok = await_death(Pid),
+    NewPid = exometer:info(M, ref),
+    ct:log("NewPid = ~p~n", [NewPid]),
+    enabled = exometer:info(M, status),
+    true = Pid =/= NewPid.
+
+killed_probe_disabled(M) ->
+    Pid = exometer:info(M, ref),
+    ct:log("Pid = ~p~n", [Pid]),
+    exit(Pid, kill),
+    ok = await_death(Pid),
+    undefined = exometer:info(M, ref),
+    ct:log("Ref = undefined~n", []),
+    disabled = exometer:info(M, status),
+    true.
+
+killed_probe_deleted(M) ->
+    Pid = exometer:info(M, ref),
+    ct:log("Pid = ~p~n", [Pid]),
+    exit(Pid, kill),
+    ok = await_death(Pid),
+    ct:log("Ets = ~p~n", [[{T,ets:tab2list(T)} ||
+                              T <- exometer_util:tables()]]),
+    {error, not_found} = exometer:get_value(M),
+    ct:log("~p deleted~n", [M]),
+    true.
+
+await_death(Pid) ->
+    Ref = erlang:send_after(1000, self(), zombie),
+    await_death(Pid, Ref).
+
+await_death(Pid, Ref) ->
+    case erlang:read_timer(Ref) of
+        false ->
+            error({process_not_dead, Pid});
+        _ ->
+            case erlang:is_process_alive(Pid) of
+                true ->
+                    erlang:bump_reductions(500),
+                    await_death(Pid, Ref);
+                false ->
+                    erlang:cancel_timer(Ref),
+                    _ = sys:get_status(exometer_admin),
+                    _ = sys:get_status(exometer_admin),
+                    ok
+            end
+    end.

--- a/test/exometer_error_SUITE.erl
+++ b/test/exometer_error_SUITE.erl
@@ -68,8 +68,14 @@ end_per_testcase(_Case, Config) ->
     ok.
 
 stop_started_apps(Config) ->
-    [application:stop(A) || A <- lists:reverse(?config(started_apps, Config))],
+    [stop_app(A) || A <- lists:reverse(?config(started_apps, Config))],
     ok.
+
+stop_app(App) ->
+    case application:stop(App) of
+        ok -> ok;
+        {error, {not_started,_}} -> ok
+    end.
 
 %%%===================================================================
 %%% Test Cases


### PR DESCRIPTION
- Delete of failed probe didn't work
- Restart parameterization support in exometer_probe (see edoc)
- Disabled probes (e.g. histograms) are now terminated
- When re-enabled, probes are re-instantitated
- If new entries include aliases, these are checked in advance
- Support for deleting all cached datapoints for a given entry
- Fix exometer:start(), which had become broken
- Make sure eunit tests succeed
- Add ct.config with lager log config
- Fix breakage in CT test case init and cleanup
- Add test suite for supervision functionality