### PR TITLE
fix bugs in logger flow control

### DIFF
--- a/src/exometer_report_logger.erl
+++ b/src/exometer_report_logger.erl
@@ -269,8 +269,8 @@ handle_cast({socket, Socket}, #st{input = L} = S) ->
     case L of
         #tcp{active = N} = T ->
             case inet:getopts(Socket, [active]) of
-                [false] ->
-                    inet:setopts(Socket, {active, N});
+                {ok, [{active, false}]} ->
+                    inet:setopts(Socket, [{active, N}]);
                 _ ->
                     ok
             end,


### PR DESCRIPTION
An error in the handling of inet:getopts/2 in the report logger was detected by dialyzer.