### PR TITLE
Make slot_histogram test more robust

### DIFF
--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -49,6 +49,8 @@
     vals/0
    ]).
 
+-import(exometer_test_util, [majority/3]).
+
 -include_lib("common_test/include/ct.hrl").
 
 %%%===================================================================
@@ -545,26 +547,3 @@ compile_app1(Config) ->
     Path = filename:join(Dir, "ebin"),
     PRes = code:add_pathz(Path),
     ct:log("add_pathz(~p) -> ~p~n", [Path, PRes]).
-
-majority(N, F, Cfg) ->
-    majority(N, F, Cfg, []).
-
-majority(0, _, _, Hist) ->
-    Failed = [1 || {caught,_,_} <- Hist],
-    ct:log("majority(): Failed = ~p, Hist=~p~n", [Failed, Hist]),
-    case {length(Failed), length(Hist)} of
-        {Lf, L} when Lf >= L div 2 ->
-            {error, {too_many_failures, Hist}};
-        _ ->
-            ok
-    end;
-majority(N, F, Cfg, Hist) when N > 0 ->
-    Res = try F(Cfg)
-          catch
-              C:R ->
-                  {caught, C, R}
-          after
-              F({cleanup, Cfg})
-          end,
-    majority(N-1, F, Cfg, [Res|Hist]).
-


### PR DESCRIPTION
The slot_histogram test tends to fail occasionally, like depending
on the fact that the update sequence is slightly timing-sensitive
(the slot_slide histograms use 10 ms time slots). This change runs
the test several times, and considers it a success if the majority
of results match the expectation.