### PR TITLE
More timing-robust test execution

### DIFF
--- a/src/exometer_probe.erl
+++ b/src/exometer_probe.erl
@@ -583,9 +583,10 @@ default_restart() ->
 behaviour() ->
     entry.
 
+delete(_Name, _Type, undefined) ->
+    ok;
 delete(_Name, _Type, Pid) when is_pid(Pid) ->
     exometer_proc:cast(Pid, delete).
-
 
 get_value(_Name, _Type, Pid) when is_pid(Pid) ->
     exometer_proc:call(Pid, {get_value, default}).

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -49,7 +49,7 @@
     vals/0
    ]).
 
--import(exometer_test_util, [majority/3]).
+-import(exometer_test_util, [majority/2]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -280,7 +280,7 @@ test_std_histogram(_Config) ->
 
 test_slot_histogram(Config) ->
     C = [?MODULE, hist, ?LINE],
-    ok = majority(5, fun test_slot_histogram_/1, [{metric_name, C}|Config]).
+    ok = majority(fun test_slot_histogram_/1, [{metric_name, C}|Config]).
 
 test_slot_histogram_({cleanup, Config}) ->
     C = ?config(metric_name, Config),

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -280,7 +280,7 @@ test_std_histogram(_Config) ->
 
 test_slot_histogram(Config) ->
     C = [?MODULE, hist, ?LINE],
-    ok = majority(fun test_slot_histogram_/1, [{metric_name, C}|Config]).
+    majority(fun test_slot_histogram_/1, [{metric_name, C}|Config]).
 
 test_slot_histogram_({cleanup, Config}) ->
     C = ?config(metric_name, Config),

--- a/test/exometer_error_SUITE.erl
+++ b/test/exometer_error_SUITE.erl
@@ -133,7 +133,7 @@ killed_probe_restarts(M) ->
     Pid = exometer:info(M, ref),
     ct:log("Pid = ~p~n", [Pid]),
     exit(Pid, kill),
-    ok = await_death(Pid),
+    await_death(Pid),
     NewPid = exometer:info(M, ref),
     ct:log("NewPid = ~p~n", [NewPid]),
     enabled = exometer:info(M, status),
@@ -143,7 +143,7 @@ killed_probe_disabled(M) ->
     Pid = exometer:info(M, ref),
     ct:log("Pid = ~p~n", [Pid]),
     exit(Pid, kill),
-    ok = await_death(Pid),
+    await_death(Pid),
     undefined = exometer:info(M, ref),
     ct:log("Ref = undefined~n", []),
     disabled = exometer:info(M, status),
@@ -153,7 +153,7 @@ killed_probe_deleted(M) ->
     Pid = exometer:info(M, ref),
     ct:log("Pid = ~p~n", [Pid]),
     exit(Pid, kill),
-    ok = await_death(Pid),
+    await_death(Pid),
     ct:log("Ets = ~p~n", [[{T,ets:tab2list(T)} ||
                               T <- exometer_util:tables()]]),
     {error, not_found} = exometer:get_value(M),
@@ -165,7 +165,8 @@ await_death(Pid) ->
     await_death(Pid, Ref),
     %% Now ping exometer_admin twice to give it time to handle the DOWN msg
     sys:get_status(exometer_admin),
-    sys:get_status(exometer_admin).
+    sys:get_status(exometer_admin),
+    ok.
 
 await_death(Pid, Ref) ->
     case erlang:read_timer(Ref) of
@@ -178,8 +179,8 @@ await_death(Pid, Ref) ->
                     await_death(Pid, Ref);
                 false ->
                     erlang:cancel_timer(Ref),
-                    _ = sys:get_status(exometer_admin),
-                    _ = sys:get_status(exometer_admin),
+                    sys:get_status(exometer_admin),
+                    sys:get_status(exometer_admin),
                     ok
             end
     end.

--- a/test/exometer_report_SUITE.erl
+++ b/test/exometer_report_SUITE.erl
@@ -161,7 +161,7 @@ test_logger_flow_control_2(Config) ->
 
 start_logger_and_reporter(Reporter, Config) ->
     Port = get_port(Config),
-    IPO = config(input_port_options, Config, []),
+    IPO = ensure_reuse(config(input_port_options, Config, [])),
     ct:log("IPO = ~p~n", [IPO]),
     Res = exometer_report_logger:new(
             [{id, ?MODULE},
@@ -184,6 +184,14 @@ start_logger_and_reporter(Reporter, Config) ->
             {port, Port},
             {intervals, [{main, manual}]}]),
     {ok, Info}.
+
+ensure_reuse(Opts) ->
+    case lists:keyfind(reuseaddr, 1, Opts) of
+        {_, _} ->
+            Opts;
+        false ->
+            [{reuseaddr, true}|Opts]
+    end.
 
 check_logger_msg() ->
     receive

--- a/test/exometer_report_SUITE.erl
+++ b/test/exometer_report_SUITE.erl
@@ -154,10 +154,10 @@ test_subscribe_select_(Config) ->
     ok.
 
 test_logger_flow_control(Config) ->
-    ok = test_subscribe_find([{input_port_options, [{active, false}]}|Config]).
+    test_subscribe_find([{input_port_options, [{active, false}]}|Config]).
 
 test_logger_flow_control_2(Config) ->
-    ok = test_subscribe_find([{input_port_options, [{active, once}]}|Config]).
+    test_subscribe_find([{input_port_options, [{active, once}]}|Config]).
 
 start_logger_and_reporter(Reporter, Config) ->
     Port = get_port(Config),

--- a/test/exometer_test_udp_reporter.erl
+++ b/test/exometer_test_udp_reporter.erl
@@ -131,7 +131,7 @@ input_loop(Socket, Parent) ->
              {plugin_active, Active} ->
                  ct:log("{plugin_active, ~p}", [Active]),
                  inet:setopts(Socket, [{active, Active}])
-         after 1000 ->
+         after 5000 ->
                  io:fwrite(user, "input_loop timeout~n", [])
          end of
         check ->

--- a/test/exometer_test_udp_reporter.erl
+++ b/test/exometer_test_udp_reporter.erl
@@ -110,6 +110,7 @@ logger_init_input({Port, Opts}) ->
     Parent = self(),
     {Pid,_} = spawn_monitor(
                 fun() ->
+                        erlang:monitor(process, Parent),
                         {ok, Socket} = gen_udp:open(Port, [binary|Opts]),
                         check_active(Socket, Parent),
                         input_loop(Socket, Parent)
@@ -130,7 +131,9 @@ input_loop(Socket, Parent) ->
                  Parent ! {plugin_passive, self()}, check;
              {plugin_active, Active} ->
                  ct:log("{plugin_active, ~p}", [Active]),
-                 inet:setopts(Socket, [{active, Active}])
+                 inet:setopts(Socket, [{active, Active}]);
+             {'DOWN', _, process, Parent, _} ->
+                 exit(normal)
          after 5000 ->
                  io:fwrite(user, "input_loop timeout~n", [])
          end of

--- a/test/exometer_test_util.erl
+++ b/test/exometer_test_util.erl
@@ -1,6 +1,7 @@
 -module(exometer_test_util).
 
 -export([ensure_all_started/1,
+         majority/2,
          majority/3]).
 
 %% This implementation is originally from Basho's Webmachine. On
@@ -33,6 +34,9 @@ ensure_all_started(App, Apps0) ->
             {ok, Apps} = ensure_all_started(BaseApp, Apps0),
             ensure_all_started(App, [BaseApp|Apps])
     end.
+
+majority(F, Cfg) ->
+    majority(5, F, Cfg).
 
 %% Run test N times. Success if a majority of the tests succeed.
 %% Cleanup between runs done by calling F({cleanup, Config})


### PR DESCRIPTION
Make more use of the majority() function in the test suites
Use 5 attempts as the default when using majority/2
Increase timeout in the reporting test