### PR TITLE
Fix retry with find/select when using static subscriptions.

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -1157,13 +1157,10 @@ do_report(#key{metric = Metric,
             true;
         %% We did not find a value, but we should try again.
         {true, _ } ->
-            if is_list(Metric) ->
             ?debug("Metric(~p) Datapoint(~p) not found."
                    " Will try again in ~p msec~n",
                    [Metric, DataPoint, Interval]),
             true;
-               true -> false
-            end;
         %% We did not find a value, and we should not retry.
         _ ->
             %% Entry removed while timer in progress.


### PR DESCRIPTION
Revert changes from 5fc843c4685be5f644bc0105e3c86f7e387116a0 that conflicted with 35e2f61990b99de66f14aa702af5767b9f5d65c5.