### PR TITLE
exometer_spiral should not set heap_size

### DIFF
--- a/src/exometer_spiral.erl
+++ b/src/exometer_spiral.erl
@@ -60,7 +60,6 @@ probe_init(Name, _Type, Options) ->
                                     fun count_sample/3,
                                     fun count_transform/2,
                                     Options),
-    process_flag(min_heap_size, 40000),
     {ok, St#st{slide = Slide}}.
 
 probe_terminate(_St) ->


### PR DESCRIPTION
Using exometer_probe, the min_heap_size is already set to 40000, but can be changed e.g. via the options list. However, if exometer_spiral explicitly sets min_heap_size in the probe_init(), not only doesn't it affect the default (since it's the same value), but it also overrides any user-provided options.