### PR TITLE
Fix start_phases for correct receiving events on reporters

### DIFF
--- a/src/exometer_core.app.src
+++ b/src/exometer_core.app.src
@@ -16,8 +16,8 @@
    [
    ]},
   {mod, {exometer_core_app, []}},
-  {start_phases, [{preset_defaults, []},
-                  {start_reporters, []}]},
+  {start_phases, [{start_reporters, []},
+                  {preset_defaults, []}]},
   {env,
    [
    ]}


### PR DESCRIPTION
We should start reporters before creating default entries because reporter needs to receive exometer_subscribe and exometer_newentry events during `preset_default` phase.