### PR TITLE
Switch folsom dependency to maintained fork

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"3.0.2"}}},
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9.2"}}},
   {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag,"0.8.2"}}},
-  {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.2"}}},
+  {folsom, ".*", {git, "git://github.com/folsom-project/folsom", "38e2cce"}}, % this used to be tag 0.8.2
   {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.6"}}}
  ]}.
 


### PR DESCRIPTION
Ref #49 

I've added this so we can move the issue forward without waiting for the proper tag in folsom.