### PR TITLE
update dep to setup 1.6

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9.2"}}},
   {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag,"0.8.2"}}},
   {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.2"}}},
-  {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.5"}}}
+  {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.6"}}}
  ]}.
 
 {erl_opts,


### PR DESCRIPTION
Updates `setup` dependency to 1.6

Verified that starting erl with `-setup verify_directories false` causes `setup` to not create data and log directories.