### PR TITLE
Remove workaround for call from exometer_histogram call

### DIFF
--- a/src/exometer_histogram.erl
+++ b/src/exometer_histogram.erl
@@ -199,7 +199,13 @@ get_value_int_(#st{truncate = Trunc,
                 {Length, lists:sort(Lst0)}
         end,
     TopPercentiles = get_from_heap(Heap, TS, TimeSpan, FullLength, DataPoints),
-    Results = exometer_util:get_statistics2(Len, List, Total, Mean),
+    Results = case List of
+                  [0, 0] ->
+                      %% a case where Min and Max are the only data, nil
+                      [];
+                  _ ->
+                      exometer_util:get_statistics2(Len, List, Total, Mean)
+              end,
     CombinedResults = TopPercentiles ++ Results,
     [get_dp(K, CombinedResults, Trunc) || K <- DataPoints].
 

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -246,12 +246,6 @@ get_statistics(L, Total, Sorted) ->
 get_statistics2(_L, [], _Total, _Mean) ->
     [];
 
-%% Special case when we get called from
-%% exometer_histogram:get_value_int() with just
-%% a nil min/max pair.
-get_statistics2(_L, [0,0], _Total, _Mean) ->
-    [];
-
 get_statistics2(L, Sorted, Total, Mean) ->
     P50 = perc(0.5, L),
     Items = [{min,1}, {50, P50}, {median, P50}, {75, perc(0.75,L)},


### PR DESCRIPTION
To address https://github.com/basho/riak_core/issues/804 , special case workaround for  `exometer_histogram:get_value_int/2` harms special case where real data `[0, 0]` exactly come to `exometer_util:histogram/1` as `Values` via `exometer:get_value/2`. As the side effect of this patch (what above workaround did for) was not clear to me and Riak seems working good to me, here I opened this patch.

I'lll eventually send this patch to https://github.com/basho/exometer_core once this get merged.