### PR TITLE
Fix return value of update/2 if update_event enabled

### DIFF
--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -240,7 +240,10 @@ update_(Name, Value) when is_list(Name) ->
 
 update_ok(St, #exometer_entry{name = Name}, Value)
   when St band 2#10 =:= 2#10 ->
-    try exometer_event ! {updated, Name, Value}
+    try begin
+	    exometer_event ! {updated, Name, Value},
+	    ok
+	end
     catch
         _:_ -> ok
     end;


### PR DESCRIPTION
When update_event enabled, update/2 would return the event
message rather than ok - that is, if the process exometer_event
existed.