### PR TITLE
Restart all reporters when restarting report.

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -629,7 +629,7 @@ init([]) ->
                     {remove, How} ->
                         case How of
                             {M, F} when is_atom(M), is_atom(F) ->
-                                try M:F(Module, parent_restart) catch _:_ -> ok end;
+                                try M:F(Module, {?MODULE, parent_restart}) catch _:_ -> ok end;
                             _ ->
                                 ok
                         end,

--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -622,6 +622,26 @@ new_entry(Entry) ->
 %%--------------------------------------------------------------------
 init([]) ->
     process_flag(trap_exit, true),
+    D = ets:foldl(
+        fun (#reporter{name = Name, module = Module, restart = Restart} = R, Acc) ->
+                terminate_reporter(R),
+                case add_restart(Restart) of
+                    {remove, How} ->
+                        case How of
+                            {M, F} when is_atom(M), is_atom(F) ->
+                                try M:F(Module, ?MODULE) catch _:_ -> ok end;
+                            _ ->
+                                ok
+                        end,
+                        [Name | Acc];
+                    {restart, Restart1} ->
+                        restart_reporter(R#reporter{restart = Restart1}),
+                        Acc
+                end
+        end,
+        [],
+        ?EXOMETER_REPORTERS),
+    [ets:delete(?EXOMETER_REPORTERS, R) || R <- D],
     {ok, #st{}}.
 
 start_reporters() ->

--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -629,7 +629,7 @@ init([]) ->
                     {remove, How} ->
                         case How of
                             {M, F} when is_atom(M), is_atom(F) ->
-                                try M:F(Module, ?MODULE) catch _:_ -> ok end;
+                                try M:F(Module, parent_restart) catch _:_ -> ok end;
                             _ ->
                                 ok
                         end,


### PR DESCRIPTION
The reporters are not monitored any more after the exometer_report is restarted.
IMHO, it's best to terminate them and restart clean.
