### PR TITLE
fix order of Extra and Interval of exometer_subscribe

### DIFF
--- a/doc/exometer_report_lager.md
+++ b/doc/exometer_report_lager.md
@@ -115,7 +115,7 @@ Example:
 
 ### exometer_subscribe/5 ###
 
-`exometer_subscribe(Metric, DataPoint, Extra, Interval, St) -> any()`
+`exometer_subscribe(Metric, DataPoint, Interval, Extra, St) -> any()`
 
 
 <a name="exometer_terminate-2"></a>
@@ -130,5 +130,3 @@ Example:
 ### exometer_unsubscribe/4 ###
 
 `exometer_unsubscribe(Metric, DataPoint, Extra, St) -> any()`
-
-

--- a/doc/exometer_report_tty.md
+++ b/doc/exometer_report_tty.md
@@ -80,7 +80,7 @@ will be reported to collectd.<a name="index"></a>
 
 ### exometer_subscribe/5 ###
 
-`exometer_subscribe(Metric, DataPoint, Extra, Interval, St) -> any()`
+`exometer_subscribe(Metric, DataPoint, Interval, Extra, St) -> any()`
 
 
 <a name="exometer_terminate-2"></a>
@@ -95,5 +95,3 @@ will be reported to collectd.<a name="index"></a>
 ### exometer_unsubscribe/4 ###
 
 `exometer_unsubscribe(Metric, DataPoint, Extra, St) -> any()`
-
-

--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -62,12 +62,12 @@
 %% cancel the creation of the custom reporting plugin.
 %%
 %%
-%% === exometer_subscribe/4 ===
+%% === exometer_subscribe/5 ===
 %%
 %% The `exometer_subscribe()' function is invoked as follows:
 %%
 %% <pre lang="erlang">
-%%      exometer_subscribe(Metric, DataPoint, Interval State)</pre>
+%%      exometer_subscribe(Metric, DataPoint, Interval, Extra, State)</pre>
 %%
 %% The custom plugin can use this notification to modify and return its
 %% state in order to prepare for future calls to `exometer_report()' with
@@ -82,6 +82,9 @@
 %% + `Interval'<br/>Specifies the interval, in milliseconds, that the
 %% subscribed-to value will be reported at, or an atom, referring to a named
 %% interval configured in the reporter.
+%%
+%% + `Extra'<br/>Specifies the extra data, which can be anything the reporter
+%% can understand.
 %%
 %% + `State'<br/>Contains the state returned by the last called plugin function.
 %%
@@ -116,12 +119,12 @@
 %% generate an error log message by exometer.
 %%
 %%
-%% === exometer_unsubscribe/3 ===
+%% === exometer_unsubscribe/4 ===
 %%
 %% The `exometer_unsubscribe()' function is invoked as follows:
 %%
 %% <pre lang="erlang">
-%%      exometer_unsubscribe(Metric, DataPoint, State)</pre>
+%%      exometer_unsubscribe(Metric, DataPoint, Extra, State)</pre>
 %%
 %% The custom plugin can use this notification to modify and return its
 %% state in order to free resources used to maintain the now de-activated
@@ -133,6 +136,9 @@
 %%
 %% + `DataPoint'<br/>Specifies the data point or data points within the
 %%  subscribed-to metric as an atom or a list of atoms.
+%%
+%% + `Extra'<br/>Specifies the extra data, which can be anything the reporter
+%% can understand.
 %%
 %% + `State'<br/>Contains the state returned by the last called plugin function.
 %%
@@ -1600,8 +1606,8 @@ reporter_loop(Module, #rst{st = St, bulk = Bulk} = RSt) ->
                       {ok, St1} -> {ok, St1};
                       _ -> {ok, St}
                   end;
-              {exometer_subscribe, Metric, DataPoint, Extra, Interval } ->
-                  case Module:exometer_subscribe(Metric, DataPoint, Extra, Interval, St) of
+              {exometer_subscribe, Metric, DataPoint, Interval, Extra } ->
+                  case Module:exometer_subscribe(Metric, DataPoint, Interval, Extra, St) of
                       {ok, St1} -> {ok, St1};
                       _ -> {ok, St}
                   end;

--- a/src/exometer_report_tty.erl
+++ b/src/exometer_report_tty.erl
@@ -58,7 +58,7 @@ exometer_init(Opts) ->
     TypeMap = proplists:get_value(type_map, Opts, []),
     {ok, #st{type_map = TypeMap}}.
 
-exometer_subscribe(_Metric, _DataPoint, _Extra, _Interval, St) ->
+exometer_subscribe(_Metric, _DataPoint, _Interval, _Extra, St) ->
     {ok, St}.
 
 exometer_unsubscribe(_Metric, _DataPoint, _Extra, St) ->

--- a/test/exometer_test_udp_reporter.erl
+++ b/test/exometer_test_udp_reporter.erl
@@ -69,7 +69,7 @@ exometer_report_bulk(Found, Extra, #st{} = St) ->
     ok = send({report_bulk, Found}, St),
     {ok, St}.
 
-exometer_subscribe(Metric, DataPoint, Extra, Interval, St) ->
+exometer_subscribe(Metric, DataPoint, Interval, Extra, St) ->
     ok = send({subscribe, [{metric, Metric},
                            {datapoint, DataPoint},
                            {extra, Extra},


### PR DESCRIPTION
There're  two orders of `exometer_subscribe/5` function(`Interval, Extra` and `Extra, Interval`), like:
https://github.com/Feuerlabs/exometer_core/blob/master/src/exometer_report.erl#L223 and 
https://github.com/Feuerlabs/exometer_core/blob/master/src/exometer_report.erl#L795
and where I changed.

So I changed them to `Interval, Extra` to keep the same with `subscribe/5` (https://github.com/Feuerlabs/exometer_core/blob/master/src/exometer_report.erl#L311)