### PR TITLE
Fix reporter crashes when a cache is used for function entries

### DIFF
--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -390,13 +390,18 @@ get_cached_value_(#exometer_entry{name = Name,
                     end, {[],[]}, DataPoints),
 
     %% Go through all cache misses and retreive their actual values.
-    Result = get_value_(E#exometer_entry { cache = 0 }, Uncached),
-
-    %% Update the cache with all the shiny new values retrieved.
-    [ exometer_cache:write(Name, DataPoint1, Value1, CacheTTL)
-      || { DataPoint1, Value1 } <- Result],
-    All = Result ++ Cached,
-    [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints].
+    case get_value_(E#exometer_entry { cache = 0 }, Uncached) of
+        {error, unavailable} = Result -> 
+            %% a function entry returns this in exception case.
+            %% see `exometer_function:get_value/4`
+            Result;
+        Result ->
+            %% Update the cache with all the shiny new values retrieved.
+            [ exometer_cache:write(Name, DataPoint1, Value1, CacheTTL)
+              || { DataPoint1, Value1 } <- Result],
+            All = Result ++ Cached,
+            [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints]
+    end.
 
 
 


### PR DESCRIPTION
Previously `exometer_reporter` process crashed in case a cache is
used for function entries. The reason is a wrong processing of the
result `{error, unavailable}` from `exometer_function:get_value/4`.
There is no supervision tree for the related processes under
`exometer_core` so the reporter processes will also fail which is
bad for stateful reporters.

This commit fixes the processing for `{error, unavailable}` and the
behavior of function entries with and without cache should be the same.

Note that this commit does not change a returned value of
`exometer:get_value/2` for such entries.
It's still `{ok, {error, unavailable}}`.