### PR TITLE
Fix reporting metrics with binary elements in name

### DIFF
--- a/src/exometer_report_tty.erl
+++ b/src/exometer_report_tty.erl
@@ -117,8 +117,10 @@ metric_to_string([H | T]) ->
 
 metric_elem_to_list(E) when is_atom(E) ->
     atom_to_list(E);
-metric_elem_to_list(E) when is_list(E); is_binary(E) ->
+metric_elem_to_list(E) when is_list(E) ->
     E;
+metric_elem_to_list(E) when is_binary(E) ->
+    [E];
 metric_elem_to_list(E) when is_integer(E) ->
     integer_to_list(E).
 


### PR DESCRIPTION
Binaries are wrapped in a list so they can be the head in an append and part of a flatten list.