### PR TITLE
Remove default min_heap_size exometer_probe

### DIFF
--- a/src/exometer_probe.erl
+++ b/src/exometer_probe.erl
@@ -641,7 +641,6 @@ start_probe(#exometer_entry{module = Module,
 %% == Probe implementation
 
 init(Name, Type, Mod, Opts) ->
-    process_flag(min_heap_size, 40000),
     {St0, Opts1} = process_opts(Opts, #st{name = Name,
                                           type = Type,
                                           module = Mod}),


### PR DESCRIPTION
Since there is an ability to set this option during creating of probe
let's use default value provided by Erlang for it.