### PR TITLE
Datapoint inconsistencies can make exometer:get_values/1 crash

### DIFF
--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -400,7 +400,8 @@ get_cached_value_(#exometer_entry{name = Name,
             [ exometer_cache:write(Name, DataPoint1, Value1, CacheTTL)
               || { DataPoint1, Value1 } <- Result],
             All = Result ++ Cached,
-            [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints]
+            [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints,
+                                                  lists:keymember(DP,1,All)]
     end.
 
 


### PR DESCRIPTION
An unnecessarily strict pattern-match in a get_cached_value_/2 LC
could crash exometer:get_values/1, if custom metrics (e.g. probes)
report the wrong set of supported datapoints. A guard in the LC
ensures that only datapoints actually present in the data will be
asked for.