### PR TITLE
Fix double send measurements

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
 
 {deps,
  [
+  {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"3.0.2"}}},
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag, "3.0.0"}}},
   {folsom, ".*", {git, "git://github.com/folsom-project/folsom", {tag, "0.8.5"}}},
   {hut, ".*", {git, "git://github.com/tolbrino/hut.git", {tag, "v1.1.1"}}},

--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -1299,7 +1299,7 @@ adjust_interval(Time, T0) ->
             %% Most likely due to clock adjustment
             {Time, T1};
         D ->
-            {D, T0}
+            {Time - D, T0}
     end.
 
 tdiff(T1, T0) ->


### PR DESCRIPTION
I found that the measurements are sent 2 times with the same timestamp. To find this bug I configured some predefined measurements, I sent it via statsd subscriber and I set the level of logger to debug. In this way I found that the measurements are sent 2 times on the same seconds (I set the interval to 5 seconds):

```
2018-02-14 19:04:40.626 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75257336
2018-02-14 19:04:40.629 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75248920
```

```
2018-02-14 19:04:45.631 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75306448
2018-02-14 19:04:45.636 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75328744
```

```
2018-02-14 19:04:50.637 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75451056
2018-02-14 19:04:50.639 [debug] <0.1462.0>@exometer_report_statsd:exometer_report:68 Report metric [<<"rezolve~core_1@elixir-node_1~local_dev">>,".","erlang",".","memory",".","total"] = 75481512
```

Debugging the code I fix this problem in this way.  I would also rewrite the function in this way that is (for me) more clear but in the PR I change the minimum required. 

```
adjust_interval(Interval, T0) ->
    Now = os:timestamp(),
    case tdiff(Now, T0) of
        Elapsed when Elapsed > Interval; Elapsed < 0 ->
            %% Most likely due to clock adjustment
            {Interval, Now};
        Elapsed ->
            {Interval - Elapsed, T0}
    end.
```