### PR TITLE
exometer_report:adjust_interval/2 faulty

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -1299,7 +1299,7 @@ adjust_interval(Time, T0) ->
             %% Most likely due to clock adjustment
             {Time, T1};
         D ->
-            {D, T0}
+            {Time-D, T0}
     end.
 
 tdiff(T1, T0) ->


### PR DESCRIPTION
When calculating a new bulk reporting interval, the `adjust_interval/2` function would return only the diff of the current time - expected time, instead of subtracting this diff from the desired interval.

This could lead to double reporting, as each batch was likely to be followed by a timer with very short duration.