### PR TITLE
Fixed handling of cache misses

### DIFF
--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -389,22 +389,25 @@ get_cached_value_(#exometer_entry{name = Name,
                             end
                     end, {[],[]}, DataPoints),
 
-    %% Go through all cache misses and retreive their actual values.
-    case get_value_(E#exometer_entry { cache = 0 }, Uncached) of
-        {error, unavailable} = Result -> 
-            %% a function entry returns this in exception case.
-            %% see `exometer_function:get_value/4`
-            Result;
-        Result ->
-            %% Update the cache with all the shiny new values retrieved.
-            [ exometer_cache:write(Name, DataPoint1, Value1, CacheTTL)
-              || { DataPoint1, Value1 } <- Result],
-            All = Result ++ Cached,
-            [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints,
-                                                  lists:keymember(DP,1,All)]
+    if Uncached == [] ->
+            %% We are done, return
+            Cached;
+       true ->
+            %% Go through all cache misses and retreive their actual values.
+            case get_value_(E#exometer_entry { cache = 0 }, Uncached) of
+                {error, unavailable} = Result ->
+                    %% a function entry returns this in exception case.
+                    %% see `exometer_function:get_value/4`
+                    Result;
+                Result ->
+                    %% Update the cache with all the shiny new values retrieved.
+                    [ exometer_cache:write(Name, DataPoint1, Value1, CacheTTL)
+                      || { DataPoint1, Value1 } <- Result],
+                    All = Result ++ Cached,
+                    [{_,_} = lists:keyfind(DP, 1, All) || DP <- DataPoints,
+                                                          lists:keymember(DP,1,All)]
+            end
     end.
-
-
 
 -spec delete(name()) -> ok | error().
 %% @doc Delete the metric


### PR DESCRIPTION
Previously the successful case of finding all values in the cache would
lead to a full read. In that case the right thing to do is just return
all cached values.

@uwiger I ran into this a while ago for some obvious hard to calculate metrics where it became apparent.