### PR TITLE
remove old instance at re_register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: erlang
 script:
-    - wget -c https://github.com/erlang/rebar3/releases/download/3.11.1/rebar3
+    - wget -c https://github.com/erlang/rebar3/releases/download/3.12.0/rebar3
     - chmod +x rebar3
     - REBAR3=./rebar3 make ci
 otp_release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ script:
     - chmod +x rebar3
     - REBAR3=./rebar3 make ci
 otp_release:
-    - 22.0.2
-    - 21.1
+    - 22.1
+    - 21.3
     - 20.3
-    - 20.1
-    - 20.0
     - 19.3
-
+    - 18.3
 after_failure: "echo 'logs/raw.log\n'; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done"

--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -270,12 +270,18 @@ handle_call({new_entry, Name, Type, Opts, AllowExisting} = _Req, _From, S) ->
         #exometer_entry{options = NewOpts} = E0 =
             lookup_definition(Name, Type, Opts),
 
-        case {ets:member(exometer_util:table(), Name), AllowExisting} of
-            {true, false} ->
+        case {ets:lookup(exometer_util:table(), Name), AllowExisting} of
+            {[_], false} ->
                 {reply, {error, exists}, S};
-            _Other ->
-		?log(debug, "_Other = ~p~n", [_Other]),
+            {LookupRes, _} ->
+		?log(debug, "LookupRes = ~p~n", [LookupRes]),
                 E1 = process_opts(E0, NewOpts),
+                try maybe_remove_old_instance(LookupRes, Name)
+                catch ?EXCEPTION(Cat, Exception, Stacktrace) ->
+                        ?log(debug, "CAUGHT(~p) ~p:~p / ~p",
+                             [Name, Cat, Exception, ?GET_STACK(Stacktrace)]),
+                        ok
+                end,
                 Res = try  exometer:create_entry(E1),
 			   exometer_report:new_entry(E1)
 		      catch
@@ -691,32 +697,9 @@ try_delete_entry_(Name) ->
 delete_entry_(Name) ->
     exometer_cache:delete_name(Name),
     case ets:lookup(exometer_util:table(), Name) of
-        [#exometer_entry{module = exometer, type = Type}] when Type==counter;
-                                                               Type==gauge ->
-            [ets:delete(T, Name) ||
-                T <- [?EXOMETER_ENTRIES|exometer_util:tables()]],
-            ok;
-        [#exometer_entry{module = exometer, type = fast_counter,
-                         ref = {M, F}}] ->
+        [#exometer_entry{} = Entry] ->
             try
-                exometer_util:set_call_count(M, F, false)
-            after
-                [ets:delete(T, Name) ||
-                    T <- [?EXOMETER_ENTRIES|exometer_util:tables()]]
-            end,
-            ok;
-        [#exometer_entry{behaviour = probe,
-                         type = Type, ref = Ref}] ->
-            try
-                exometer_probe:delete(Name, Type, Ref)
-            after
-                [ets:delete(T, Name) ||
-                    T <- [?EXOMETER_ENTRIES|exometer_util:tables()]]
-            end,
-            ok;
-        [#exometer_entry{module= Mod, behaviour = entry,
-                         type = Type, ref = Ref}] ->
-            try Mod:delete(Name, Type, Ref)
+                remove_old_instance(Entry, Name)
             after
                 [ets:delete(T, Name) ||
                     T <- [?EXOMETER_ENTRIES|exometer_util:tables()]]
@@ -725,3 +708,20 @@ delete_entry_(Name) ->
         [] ->
             {error, not_found}
     end.
+
+maybe_remove_old_instance([], _) ->
+    ok;
+maybe_remove_old_instance([Entry], Name) ->
+    remove_old_instance(Entry, Name).
+
+remove_old_instance(#exometer_entry{module = exometer, type = fast_counter,
+                                    ref = {M, F}}, _) ->
+    exometer_util:set_call_count(M, F, false);
+remove_old_instance(#exometer_entry{behaviour = probe,
+                                    type = Type, ref = Ref}, Name) ->
+    exometer_probe:delete(Name, Type, Ref);
+remove_old_instance(#exometer_entry{module = Mod, behaviour = entry,
+                                    type = Type, ref = Ref}, Name) ->
+    Mod:delete(Name, Type, Ref);
+remove_old_instance(_, _) ->
+    ok.

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -39,6 +39,7 @@
     test_history4_slide/1,
     test_history4_slotslide/1,
     test_history4_folsom/1,
+    test_re_register_probe/1,
     test_ext_predef/1,
     test_app_predef/1,
     test_function_match/1,
@@ -65,6 +66,7 @@ all() ->
      {group, test_counter},
      {group, test_defaults},
      {group, test_histogram},
+     {group, re_register},
      {group, test_setup},
      {group, test_info}
     ].
@@ -98,6 +100,10 @@ groups() ->
        test_history4_slide,
        test_history4_slotslide,
        test_history4_folsom
+      ]},
+     {re_register, [shuffle],
+      [
+       test_re_register_probe
       ]},
      {test_setup, [shuffle],
       [
@@ -392,6 +398,18 @@ test_history4_slotslide(_Config) ->
 
 test_history4_folsom(_Config) ->
     test_history(4, folsom, file_path("test/data/puts_time_hist4.bin")).
+
+test_re_register_probe(_Config) ->
+    K = ?LINE,
+    ok = exometer:re_register(S1 = [?MODULE, K, s, 1], spiral, []),  % re_register as new/3
+    P1 = exometer:info(S1, ref),
+    true = erlang:is_process_alive(P1),
+    ok = exometer:re_register(S1, spiral, []),
+    P2 = exometer:info(S1, ref),
+    true = (P1 =/= P2),
+    false = erlang:is_process_alive(P1),
+    true = erlang:is_process_alive(P2),
+    ok.
 
 file_path(F) ->
     filename:join(code:lib_dir(exometer_core), F).

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -403,6 +403,7 @@ test_re_register_probe(_Config) ->
     K = ?LINE,
     ok = exometer:re_register(S1 = [?MODULE, K, s, 1], spiral, []),  % re_register as new/3
     P1 = exometer:info(S1, ref),
+    MRef = monitor(process, P1),  % in this specific case, we know P1 is a process
     true = erlang:is_process_alive(P1),
     ok = exometer:re_register(S1, spiral, []),
     P2 = exometer:info(S1, ref),
@@ -410,8 +411,12 @@ test_re_register_probe(_Config) ->
     %% removal of old probe is asynchronous ...
     %% TODO: some more sophistication in replacing the old instance
     %% might be called for.
-    timer:sleep(100),
-    false = erlang:is_process_alive(P1),
+    receive
+        {'DOWN', MRef, _, _, _} ->
+            ok
+    after 1000 ->
+            error(timeout)
+    end,
     true = erlang:is_process_alive(P2),
     ok.
 

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -407,6 +407,10 @@ test_re_register_probe(_Config) ->
     ok = exometer:re_register(S1, spiral, []),
     P2 = exometer:info(S1, ref),
     true = (P1 =/= P2),
+    %% removal of old probe is asynchronous ...
+    %% TODO: some more sophistication in replacing the old instance
+    %% might be called for.
+    timer:sleep(100),
     false = erlang:is_process_alive(P1),
     true = erlang:is_process_alive(P2),
     ok.


### PR DESCRIPTION
Fixes #120 

This change ensures that old instances are removed as for `delete/1` upon re_register.