### PR TITLE
Ensure slides ignore outdated values

### DIFF
--- a/src/exometer_slide.erl
+++ b/src/exometer_slide.erl
@@ -167,7 +167,8 @@ to_list(#slide{size = Sz}) when Sz == 0 ->
     [];
 to_list(#slide{size = Sz, n = N, max_n = MaxN, buf1 = Buf1, buf2 = Buf2}) ->
     Start = timestamp() - Sz,
-    take_since(Buf2, Start, n_diff(MaxN, N), reverse(Buf1)).
+    Buf1Values = take_since(Buf1, Start, n_diff(MaxN, N), []),
+    take_since(Buf2, Start, n_diff(MaxN, N), reverse(Buf1Values)).
 
 -spec foldl(timestamp(), fold_fun(), fold_acc(), #slide{}) -> fold_acc().
 %% @doc Fold over the sliding window, starting from `Timestamp'.
@@ -180,9 +181,9 @@ foldl(_Timestamp, _Fun, _Acc, #slide{size = Sz}) when Sz == 0 ->
 foldl(Timestamp, Fun, Acc, #slide{size = Sz, n = N, max_n = MaxN,
                                   buf1 = Buf1, buf2 = Buf2}) ->
     Start = Timestamp - Sz,
-    lists:foldr(
-      Fun, lists:foldl(Fun, Acc, take_since(
-                                   Buf2, Start, n_diff(MaxN,N), [])), Buf1).
+    Buf1Values = take_since(Buf1, Start, n_diff(MaxN, N), []),
+    Buf2Values = take_since(Buf2, Start, n_diff(MaxN, N), []),
+    lists:foldr(Fun, lists:foldl(Fun, Acc, Buf2Values), Buf1Values).
 
 -spec foldl(fold_fun(), fold_acc(), #slide{}) -> fold_acc().
 %% @doc Fold over all values in the sliding window.

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -507,7 +507,6 @@ test_slide_ignore_outdated(_Config) ->
 
    % check that new entry exists
    {ok, V2} = exometer:get_value(M),
-   ct:pal("~p", [V2]),
    1 = proplists:get_value(n, V2),
 
    % wait

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -43,7 +43,8 @@
     test_ext_predef/1,
     test_app_predef/1,
     test_function_match/1,
-    test_status/1
+    test_status/1,
+    test_slide_ignore_outdated/1
    ]).
 
 %% utility exports
@@ -99,7 +100,8 @@ groups() ->
        test_history1_folsom,
        test_history4_slide,
        test_history4_slotslide,
-       test_history4_folsom
+       test_history4_folsom,
+       test_slide_ignore_outdated
       ]},
      {re_register, [shuffle],
       [
@@ -485,6 +487,37 @@ test_status(_Config) ->
      {options, Opts2},
      {ref, undefined}] = exometer:info(M1),
     ok.
+
+%% Ensure a slide ignores values which are outdated as per its configuration of
+%% time_span. This is important in cases with low update frequencies.
+test_slide_ignore_outdated(_Config) ->
+   M = [?MODULE, hist, ?LINE],
+
+   ok = exometer:new(
+          M, ad_hoc, [{module, exometer_histogram},
+                      {type, histogram},
+                      {histogram_module, exometer_slide},
+                      {time_span, 5}]),
+   % check that no entries exist
+   {ok, V1} = exometer:get_value(M),
+   0 = proplists:get_value(n, V1),
+
+   % add entry
+   ok = exometer:update(M, 1234),
+
+   % check that new entry exists
+   {ok, V2} = exometer:get_value(M),
+   ct:pal("~p", [V2]),
+   1 = proplists:get_value(n, V2),
+
+   % wait
+   timer:sleep(10),
+
+   % check that entries have expired
+   {ok, V3} = exometer:get_value(M),
+   0 = proplists:get_value(n, V3),
+
+   ok.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Previously the slide would still consider old outdated values until new values came in.