### PR TITLE
Don't duplicate the metric options.

### DIFF
--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -332,7 +332,7 @@ handle_call({ensure, Name, Type, Opts}, _From, S) ->
         [] ->
             #exometer_entry{options = OptsTemplate} = E0 =
                 lookup_definition(Name, Type, Opts),
-            E1 = process_opts(E0, OptsTemplate ++ Opts),
+            E1 = process_opts(E0, OptsTemplate),
             Res = exometer:create_entry(E1),
             report_new_entry(E1),
             {reply, Res, S}

--- a/test/exometer_SUITE.erl
+++ b/test/exometer_SUITE.erl
@@ -43,7 +43,8 @@
     test_app_predef/1,
     test_function_match/1,
     test_status/1,
-    test_slide_ignore_outdated/1
+    test_slide_ignore_outdated/1,
+    test_info_options/1
    ]).
 
 %% utility exports
@@ -113,7 +114,8 @@ groups() ->
       ]},
      {test_info, [shuffle],
       [
-       test_status
+       test_status,
+       test_info_options
       ]}
     ].
 
@@ -501,6 +503,13 @@ test_slide_ignore_outdated(_Config) ->
    0 = proplists:get_value(n, V3),
 
    ok.
+
+
+% Check if options are not duplicated.
+test_info_options(_Config) ->
+    ok = exometer:new([?FUNCTION_NAME], gauge, [{custom_opt, works}]),
+    [{custom_opt,works}] = exometer:info([?FUNCTION_NAME], options).
+
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Before this change, the options were duplicated:

```erlang
1> exometer:ensure([a], gauge, [{description, "very nice"}]).
2> exometer:info([a]).
[{name,[a]},
 {type,gauge},
 {behaviour,undefined},
 {module,exometer},
 {status,enabled},
 {cache,0},
 {value,[{value,0},{ms_since_reset,13018}]},
 {timestamp,466310610978},
 {options,[{description,"very nice"},
           {description,"very nice"}]},
 {ref,undefined}]
```
