### PR TITLE
Remove legacy macros, hut

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26]
+        otp_version: [25, 26, 27]
         os: [ubuntu-latest]
 
     container:

--- a/include/exometer.hrl
+++ b/include/exometer.hrl
@@ -36,11 +36,3 @@
 -record(exometer_shared, {
           name
          }).
-
--ifdef(OTP_RELEASE). %% this implies 21 or higher
--define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
--define(GET_STACK(Stacktrace), Stacktrace).
--else.
--define(EXCEPTION(Class, Reason, _), Class:Reason).
--define(GET_STACK(_), erlang:get_stacktrace()).
--endif.

--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,10 @@
 {deps,
  [
   {parse_trans, "3.4.1"},
-  {hut, "1.3.0"},
-  {setup, "2.1.0"}
+  {setup, "2.2.1"}
  ]}.
+
+{minimum_otp_vsn, "25.1"}.
 
 {project_plugins, [rebar3_ex_doc]}.
 {hex, [{doc, ex_doc}]}.
@@ -15,7 +16,7 @@
 
 {profiles,
  [
-  {test, [{deps, [{meck, "0.9.2"}]},
+  {test, [{deps, [{meck, "1.0.0"}]},
           {extra_src_dirs, [{"test", [{recursive, true}]}]}
          ]},
   {edown, [{deps, [{edown, "0.9.1"}]},
@@ -36,11 +37,13 @@
  [
   debug_info,
   fail_on_warning,
-  {platform_define, "^((1[8|9])|2)", rand_module},
   {verbosity, trace}
  ]}.
 
 {sub_dirs, ["src"]}.
+
+{dialyzer, [{plt_apps, all_deps},
+            {base_plt_apps, [erts, kernel, stdlib, parse_trans, setup]}]}.
 
 {xref_checks,
  [

--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -48,7 +48,7 @@
 -export([monitor/2, monitor/3, demonitor/1]).
 
 -compile({no_auto_import, [monitor/3]}).
--include_lib("hut/include/hut.hrl").
+-include_lib("kernel/include/logger.hrl").
 -include("exometer.hrl").
 
 -record(st, {}).
@@ -127,7 +127,7 @@ do_load_defaults(Src, L) when is_list(L) ->
               try set_default(NamePattern, Type, Spec)
               catch
                   error:E ->
-                      ?log(error, "Defaults(~p): ERROR: ~p~n", [Src, E])
+                      ?LOG_ERROR("Defaults(~p): ERROR: ~p~n", [Src, E])
               end
       end, L).
 
@@ -145,8 +145,8 @@ do_load_predef(Src, L) when is_list(L) ->
                 fun({K,_,_}) ->
                         predef_delete_entry(K, Src);
                    (Other) ->
-                        ?log(error, "Predef(~p): ~p~n",
-                                    [Src, {bad_pattern,Other}])
+                        ?LOG_ERROR("Predef(~p): ~p~n",
+                                   [Src, {bad_pattern,Other}])
                 end, Found);
          ({aliases, Aliases}) ->
               lists:foreach(
@@ -159,7 +159,7 @@ predef_delete_entry(Key, Src) ->
     case delete_entry(Key) of
         ok -> ok;
         Error ->
-            ?log(error, "Predef(~p): ~p~n", [Src, Error])
+            ?LOG_ERROR("Predef(~p): ~p~n", [Src, Error])
     end.
 
 ok({ok, Res}, _) -> Res;
@@ -278,27 +278,26 @@ handle_call({new_entry, Name, Type, Opts, AllowExisting} = _Req, _From, S) ->
                 try
                    remove_old_instance(LookupRes, Name)
                 catch
-                    ?EXCEPTION(Cat, Exception, Stacktrace1) ->
-                        ?log(debug, "CAUGHT(~p) ~p:~p / ~p",
-                             [Name, Cat, Exception, ?GET_STACK(Stacktrace1)]),
+                    Cat:Exception:Stacktrace1 ->
+                        ?LOG_DEBUG("CAUGHT(~p) ~p:~p / ~p",
+                                   [Name, Cat, Exception, Stacktrace1]),
                         ok
                 end,
                 Res = try
                           exometer:create_entry(E1),
                           exometer_report:new_entry(E1)
                       catch
-                          ?EXCEPTION(error, Error1, Stacktrace2) ->
-                              ?log(debug,
-                                   "ERROR create_entry(~p) :- ~p~n~p",
-                                   [E1, Error1, ?GET_STACK(Stacktrace2)]),
+                          error:Error1:Stacktrace2 ->
+                              ?LOG_DEBUG("ERROR create_entry(~p) :- ~p~n~p",
+                                         [E1, Error1, Stacktrace2]),
                               erlang:error(Error1)
                       end,
                 {reply, Res, S}
         end
     catch
-        ?EXCEPTION(error, Error, Stacktrace) ->
-            ?log(error, "~p -*-> error:~p~n~p~n",
-                 [_Req, Error, ?GET_STACK(Stacktrace)]),
+        error:Error:Stacktrace ->
+            ?LOG_ERROR("~p -*-> error:~p~n~p~n",
+                       [_Req, Error, Stacktrace]),
             {reply, {error, Error}, S}
     end;
 handle_call({repair_entry, Name}, _From, S) ->
@@ -456,14 +455,14 @@ on_error(Name, delete) ->
     try_delete_entry_(Name);
 on_error(_Proc, _OnError) ->
     %% Not good, but will do for now.
-    ?log(debug, "Unrecognized OnError: ~p (~p)~n", [_OnError, _Proc]),
+    ?LOG_DEBUG("Unrecognized OnError: ~p (~p)~n", [_OnError, _Proc]),
     ok.
 
 call_restart(M, F, A) ->
     apply(M, F, A).
 
 restart_failed(Name, Error) ->
-    ?log(debug, "Restart failed ~p: ~p~n", [Name, Error]),
+    ?LOG_DEBUG("Restart failed ~p: ~p~n", [Name, Error]),
     if is_list(Name) ->
 	    try_delete_entry_(Name);
        true ->
@@ -681,7 +680,7 @@ try_disable_entry_(Name) when is_list(Name) ->
     try exometer:setopts(Name, [{status, disabled}])
     catch
         error:Err ->
-            ?log(debug, "Couldn't disable ~p: ~p~n", [Name, Err]),
+            ?LOG_DEBUG("Couldn't disable ~p: ~p~n", [Name, Err]),
             try_delete_entry_(Name)
     end;
 try_disable_entry_(_Name) ->
@@ -691,7 +690,7 @@ try_delete_entry_(Name) ->
     try delete_entry_(Name)
     catch
 	error:R ->
-	    ?log(debug, "Couldn't delete ~p: ~p~n", [Name, R]),
+	    ?LOG_DEBUG("Couldn't delete ~p: ~p~n", [Name, R]),
 	    ok
     end.
 

--- a/src/exometer_core.app.src
+++ b/src/exometer_core.app.src
@@ -2,7 +2,7 @@
              [{description,"Code instrumentation and metrics collection package."},
               {vsn,git},
               {registered,[]},
-              {applications,[kernel,stdlib,hut,setup,parse_trans]},
+              {applications,[kernel,stdlib,setup,parse_trans]},
               {included_applications,[]},
               {mod,{exometer_core_app,[]}},
               {start_phases,[{start_reporters,[]},{preset_defaults,[]}]},

--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -213,7 +213,7 @@
 
 -export_type([metric/0, datapoint/0, interval/0, extra/0]).
 
--include_lib("hut/include/hut.hrl").
+-include_lib("kernel/include/logger.hrl").
 -include("exometer.hrl").
 
 -define(SERVER, ?MODULE).
@@ -692,7 +692,7 @@ start_reporters() ->
 
 do_start_reporters(S) ->
     Opts = get_report_env(),
-    ?log(info, "Starting reporters with ~p~n", [ Opts ]),
+    ?LOG_INFO("Starting reporters with ~p~n", [ Opts ]),
     %% Dig out the mod opts.
     %% { reporters, [ {reporter1, [{opt1, val}, ...]}, {reporter2, [...]}]}
     %% Traverse list of reporter and launch reporter gen servers as dynamic
@@ -1131,7 +1131,7 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, #st{} = S) ->
     {noreply, S};
 
 handle_info(_Info, State) ->
-    ?log(warning, "exometer_report:info(??): ~p~n", [ _Info ]),
+    ?LOG_WARNING("exometer_report:info(??): ~p~n", [ _Info ]),
     {noreply, State}.
 
 restart_reporter(#reporter{name = Name, opts = Opts, restart = Restart}) ->
@@ -1200,7 +1200,7 @@ handle_report(#key{reporter = Reporter} = Key, Interval, TS, #st{} = St) ->
                 end;
             false ->
                 %% Possibly an unsubscribe removed the subscriber
-                ?log(error, "No such subscriber (Key=~p)~n", [Key])
+                ?LOG_ERROR("No such subscriber (Key=~p)~n", [Key])
         end,
     St.
 
@@ -1215,15 +1215,15 @@ do_report(#key{metric = Metric,
             true;
         %% We did not find a value, but we should try again.
         {true, _ } ->
-            ?log(debug, "Metric(~p) Datapoint(~p) not found."
-                   " Will try again in ~p msec~n",
-                   [Metric, DataPoint, Interval]),
+            ?LOG_DEBUG("Metric(~p) Datapoint(~p) not found."
+                       " Will try again in ~p msec~n",
+                       [Metric, DataPoint, Interval]),
             true;
         %% We did not find a value, and we should not retry.
         _ ->
             %% Entry removed while timer in progress.
-            ?log(warning, "Metric(~p) Datapoint(~p) not found. Will not try again~n",
-                     [Metric, DataPoint]),
+            ?LOG_WARNING("Metric(~p) Datapoint(~p) not found. Will not try again~n",
+                         [Metric, DataPoint]),
             false
     end.
 
@@ -1489,8 +1489,8 @@ subscribe_(Reporter, Metric, DataPoint, Interval, RetryFailedMetrics,
               },
     case ets:lookup(?EXOMETER_SUBS, Key) of
         [] ->
-            ?log(debug, "subscribe_(~p, ~p, ~p, ~p, ~p, ~p, ~p)~n",
-                 [Reporter, Metric, DataPoint, Interval, RetryFailedMetrics, Extra, Status]),
+            ?LOG_DEBUG("subscribe_(~p, ~p, ~p, ~p, ~p, ~p, ~p)~n",
+                       [Reporter, Metric, DataPoint, Interval, RetryFailedMetrics, Extra, Status]),
             ets:insert(?EXOMETER_SUBS,
                        #subscriber{key = Key,
                                    interval = Interval,
@@ -1512,8 +1512,8 @@ unsubscribe_(Reporter, Metric, DataPoint, Extra) ->
                                          datapoint = DataPoint,
                                          extra = Extra}) of
         [#subscriber{} = Sub] ->
-            ?log(info, "unsubscribe_(~p, ~p, ~p, ~p)~n",
-                 [ Reporter, Metric, DataPoint, Extra]),
+            ?LOG_INFO("unsubscribe_(~p, ~p, ~p, ~p)~n",
+            [ Reporter, Metric, DataPoint, Extra]),
             unsubscribe_(Sub);
         [] ->
             not_found
@@ -1531,9 +1531,9 @@ unsubscribe_(#subscriber{key = #key{reporter = Reporter,
 report_values(Found, #key{reporter = Reporter, extra = Extra} = Key) ->
     try Reporter ! {exometer_report, Found, Extra}
     catch
-        ?EXCEPTION(error, Reason, Stacktrace) ->
-            ?log(error, "~p~nKey = ~p~nTrace: ~p",
-                        [Reason, Key, ?GET_STACK(Stacktrace)])
+        error:Reason:Stacktrace ->
+            ?LOG_ERROR("~p~nKey = ~p~nTrace: ~p",
+                       [Reason, Key, Stacktrace])
     end.
 
 retrieve_metric({Metric, Type, Enabled}, Acc) ->
@@ -1563,7 +1563,7 @@ get_subscribers(Metric, Type, Status,
                               metric = Metric,
                               datapoint = SDataPoint
                              }} | T ]) ->
-    ?log(debug,"get_subscribers(~p, ~p, ~p): match~n", [ Metric, SDataPoint, SReporter]),
+    ?LOG_DEBUG("get_subscribers(~p, ~p, ~p): match~n", [ Metric, SDataPoint, SReporter]),
     [ { SReporter, SDataPoint } | get_subscribers(Metric, Type, Status, T) ];
 
 %% get_subscribers(Metric, Type, Status,
@@ -1589,8 +1589,8 @@ get_subscribers(Metric, Type, Status,
                               metric = SMetric,
                               datapoint = SDataPoint
                              }} | T]) ->
-    ?log(debug, "get_subscribers(~p, ~p, ~p) nomatch(~p) ~n",
-           [ SMetric, SDataPoint, SReporter, Metric]),
+    ?LOG_DEBUG("get_subscribers(~p, ~p, ~p) nomatch(~p) ~n",
+               [ SMetric, SDataPoint, SReporter, Metric]),
     get_subscribers(Metric, Type, Status, T).
 
 %% Purge all subscriptions associated with a specific reporter
@@ -1619,7 +1619,7 @@ reporter_init(Reporter, Opts) ->
         {ok, St} ->
             {ok, Module, #rst{st = St, bulk = Bulk}};
         {error, Reason} ->
-            ?log(error, "Failed to start reporter ~p: ~p~n", [Module, Reason]),
+            ?LOG_ERROR("Failed to start reporter ~p: ~p~n", [Module, Reason]),
             exit(Reason)
     end.
 
@@ -1670,7 +1670,7 @@ reporter_loop(Module, #rst{st = St, bulk = Bulk} = RSt) ->
                   end;
               %% Allow reporters to generate their own callbacks.
               Other ->
-                  ?log(debug, "Custom invocation: ~p(~p)~n", [ Module, Other]),
+                  ?LOG_DEBUG("Custom invocation: ~p(~p)~n", [ Module, Other]),
                   case Module:exometer_info(Other, St) of
                       {ok, St1} -> {ok, St1};
                       _ -> {ok, St}
@@ -1749,7 +1749,7 @@ init_subscriber({select, Expr}) when tuple_size(Expr)==4;
       end, Entries);
 
 init_subscriber(Other) ->
-    ?log(warning, "Incorrect static subscriber spec ~p. "
+    ?LOG_WARNING("Incorrect static subscriber spec ~p. "
              "Use { Reporter, Metric, DataPoint [, Interval [, Extra ] ]}~n",
              [ Other ]).
 

--- a/src/exometer_report_tty.erl
+++ b/src/exometer_report_tty.erl
@@ -40,7 +40,7 @@
     exometer_terminate/2
    ]).
 
--include_lib("hut/include/hut.hrl").
+-include_lib("kernel/include/logger.hrl").
 -include("exometer.hrl").
 
 -define(SERVER, ?MODULE).
@@ -54,7 +54,7 @@
 %%%===================================================================
 
 exometer_init(Opts) ->
-    ?log(info, "~p(~p): Starting~n", [?MODULE, Opts]),
+    ?LOG_INFO("~p(~p): Starting~n", [?MODULE, Opts]),
     TypeMap = proplists:get_value(type_map, Opts, []),
     {ok, #st{type_map = TypeMap}}.
 
@@ -67,7 +67,7 @@ exometer_unsubscribe(_Metric, _DataPoint, _Extra, St) ->
 %% Invoked through the remote_exometer() function to
 %% send out an update.
 exometer_report(Metric, DataPoint, Extra, Value, St)  ->
-    ?log(debug, "Report metric ~p_~p = ~p~n", [Metric, DataPoint, Value]),
+    ?LOG_DEBUG("Report metric ~p_~p = ~p~n", [Metric, DataPoint, Value]),
     %% Report the value and setup a new refresh timer.
     Key = Metric ++ [DataPoint],
     Type = case exometer_util:report_type(Key, Extra, St#st.type_map) of
@@ -80,15 +80,15 @@ exometer_report(Metric, DataPoint, Extra, Value, St)  ->
     {ok, St}.
 
 exometer_call(Unknown, From, St) ->
-    ?log(info, "Unknown call ~p from ~p", [Unknown, From]),
+    ?LOG_INFO("Unknown call ~p from ~p", [Unknown, From]),
     {ok, St}.
 
 exometer_cast(Unknown, St) ->
-    ?log(info, "Unknown cast: ~p", [Unknown]),
+    ?LOG_INFO("Unknown cast: ~p", [Unknown]),
     {ok, St}.
 
 exometer_info(Unknown, St) ->
-    ?log(info, "Unknown info: ~p", [Unknown]),
+    ?LOG_INFO("Unknown info: ~p", [Unknown]),
     {ok, St}.
 
 exometer_newentry(_Entry, St) ->

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -377,7 +377,6 @@ ensure_all_started(App) ->
     %% in earlier R16B versions of OTP
     ensure_all_started(App, []).
 
--ifdef(rand_module).
 seed() ->
     {0, 0, 0}.
 
@@ -393,24 +392,6 @@ uniform() ->
 
 uniform(N) ->
     rand:uniform(N).
-
--else.
-seed() ->
-    random:seed().
-
-seed0() ->
-    random:seed0().
-
-seed({A, B, C}) ->
-    random:seed({A, B, C}).
-
-uniform() ->
-    random:uniform().
-
-uniform(N) ->
-    random:uniform(N).
-
--endif.
 
 %% This implementation is originally from Basho's
 %% Webmachine. Reimplementation of ensure_all_started. NOTE this does


### PR DESCRIPTION
Exometer_core now uses `logger` for logging. Hut therefore not needed.
Macros and ifdefs for handling legacy constructs (stacktraces, `random`module) removed.